### PR TITLE
WIP: Switch to using the new `GLBParser`/`GLBBuilder` from `loaders.gl`

### DIFF
--- a/modules/builder/package.json
+++ b/modules/builder/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "dependencies": {
-    "loaders.gl": "^0.1.0"
+    "loaders.gl": "^0.3.0"
   },
   "scripts": {
     "clean": "rm -fr dist && mkdir -p dist",

--- a/modules/parser/package.json
+++ b/modules/parser/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "color": "^3.0.0",
     "dotty": "^0.0.2",
-    "loaders.gl": "^0.1.0",
+    "loaders.gl": "^0.3.0",
     "math.gl": "^2.0.0",
     "probe.gl": "^1.0.0",
     "viewport-mercator-project": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5448,9 +5448,9 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-loaders.gl@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/loaders.gl/-/loaders.gl-0.1.0.tgz#53541423262c19c0881f2f4af2c3c4bfdf973ab2"
+loaders.gl@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/loaders.gl/-/loaders.gl-0.3.0.tgz#ef09a69ea9a8e233c8f1f507b725518a4cbed757"
   dependencies:
     d3-request "^1.0.6"
     webgl-obj-loader "^1.1.3"


### PR DESCRIPTION
This diff to be an integration of `loaders.gl` into xviz, which includes the significantly refactored `GLBParser` and `GLBBuilder`.

This PR is not required for binary image support, but once integrated will encode images as glTF images rather than as glTF accessors.

It will also make it easy to bring in future upgrades such as point cloud compression. 
