### PR TITLE
Fix ETL use case

### DIFF
--- a/docs/api-reference/xviz-configuration.md
+++ b/docs/api-reference/xviz-configuration.md
@@ -18,13 +18,7 @@ Parser plugins:
 - `preProcessPrimitive` (Function) - Pre process a primitive. This can be used to change the type of a primitive (e.g. from `point` to `text`) and/or modify their properties.
 - `postProcessMetadata` (Function) - Post process a metadata message.
 - `postProcessTimeslice` (Function) - Post process a timeslice message.
-- `postProcessVehiclePose` (Function) - Post process the vehicle pose object. If overridden, must return the following:
-    + `origin` (Array) - the reference point for all relative coordinates, in `[longitude, latitude, altitude]`.
-    + `trackPosition` (Array) - the target of the camera, in `[longitude, latitude, altitude]`.
-    + `heading` (Number) - heading of the vehicle, in degrees.
-    + `mapRelativeTransform` (Matrix4, optional) - must supply if any stream uses `map_relative` coordinates
-    + `vehicleRelativeTransform` (Matrix4, optional) - must supply if any stream uses `vehicle_relative` coordinates
-    + `customTransform` (Matrix4, optional) - must supply if any stream uses `custom` coordinates
+- `postProcessVehiclePose` (Function) - Post process the vehicle pose object.
 - `postProcessFrame` (Function) - Called before the current log frame is rendered.
 - `getTrackedObjectPosition` (Function) - Returns the tracking position of a selected object. The returned position should be in the same coordinate system as the object stream, in `[x, y, z]`. By default, returns the centroid of the primitive in the object stream.
 - `observeObjects` (Function) - called when new objects arrive in the object stream. Can be used to track all objects in the log.

--- a/modules/parser/src/config/xviz-config.js
+++ b/modules/parser/src/config/xviz-config.js
@@ -1,5 +1,3 @@
-import {defaultPostProcessVehiclePose} from '../parsers/parse-vehicle-pose';
-
 const DEFAULT_XVIZ_CONFIG = {
   // Config
   DEFAULT_METADATA: {},
@@ -18,9 +16,9 @@ const DEFAULT_XVIZ_CONFIG = {
   postProcessMetadata: metadata => metadata,
   preProcessPrimitive: primitive => primitive, // Applied before normalize primitive
   postProcessTimeslice: timeslice => timeslice, // Post process timeslice
+  postProcessVehiclePose: vehiclePose => vehiclePose, // Process vehicle pose from datum
 
   // TODO - these are used at render time instead of parse time. Need API audit
-  postProcessVehiclePose: defaultPostProcessVehiclePose, // Process vehicle pose from datum
   postProcessFrame: frame => frame, // Post process log frame, used in LogSlice.getCurrentFrame
   getTrackedObjectPosition: _ => null,
   observeObjects: () => {}

--- a/modules/parser/src/parsers/parse-stream-data-message.js
+++ b/modules/parser/src/parsers/parse-stream-data-message.js
@@ -81,7 +81,7 @@ export function parseStreamLogData(data, opts = {}) {
 
 // Extracts a TIMESLICE message
 function parseTimesliceData(data, convertPrimitive) {
-  const {PRIMARY_POSE_STREAM, postProcessTimeslice} = getXvizConfig();
+  const {PRIMARY_POSE_STREAM, postProcessTimeslice, postProcessVehiclePose} = getXvizConfig();
   const {vehicle_pose: vehiclePose, state_updates: stateUpdates, ...otherInfo} = data;
 
   let timestamp;
@@ -115,7 +115,8 @@ function parseTimesliceData(data, convertPrimitive) {
   }
 
   if (vehiclePose) {
-    newStreams[PRIMARY_POSE_STREAM] = vehiclePose;
+    result.vehiclePose = postProcessVehiclePose(vehiclePose);
+    newStreams[PRIMARY_POSE_STREAM] = result.vehiclePose;
   }
 
   return postProcessTimeslice ? postProcessTimeslice(result) : result;

--- a/modules/parser/src/synchronizers/log-slice.js
+++ b/modules/parser/src/synchronizers/log-slice.js
@@ -1,6 +1,8 @@
 import {getXvizConfig} from '../config/xviz-config';
 import XvizObject from '../objects/xviz-object';
 
+import {getTransformsFromPose} from '../parsers/parse-vehicle-pose';
+
 // LOGSLICE CLASS
 
 // One time slice, one datum from each stream.
@@ -23,13 +25,14 @@ export default class LogSlice {
       return null;
     }
 
-    const {postProcessFrame, postProcessVehiclePose, OBJECT_STREAM} = getXvizConfig();
+    const {postProcessFrame, OBJECT_STREAM} = getXvizConfig();
 
     const objects = XvizObject.getAllInCurrentFrame(); // Map of XVIZ ids in current slice
 
     const frame = {
       ...others,
-      ...postProcessVehiclePose(vehiclePose),
+      ...getTransformsFromPose(vehiclePose),
+      vehiclePose,
       trackedObjectPosition,
       features: this.features,
       lookAheads: this.lookAheads,


### PR DESCRIPTION
revert `postProcessVehiclePose` change in https://github.com/uber/xviz/pull/12

Tested with xviz-viewer and internal app