### PR TITLE
fix builder for generating the correct format of variables

### DIFF
--- a/modules/builder/src/builders/xviz-builder.js
+++ b/modules/builder/src/builders/xviz-builder.js
@@ -217,11 +217,7 @@ export default class XVIZBuilder {
           type: this._type
         };
 
-        if (this._data.variables[this.stream_id]) {
-          this._data.variables[this.stream_id].push(obj);
-        } else {
-          this._data.variables[this.stream_id] = [obj];
-        }
+        this._data.variables[this.stream_id] = obj;
       }
 
       if (this._category === CATEGORY.primitive) {

--- a/modules/parser/src/parsers/parse-stream-data-message.js
+++ b/modules/parser/src/parsers/parse-stream-data-message.js
@@ -9,7 +9,6 @@ import {LOG_STREAM_MESSAGE, STREAM_DATA_CONTENT} from '../constants';
 import {getXvizConfig} from '../config/xviz-config';
 
 import {parseLogMetadata} from './parse-log-metadata';
-import {parseVehiclePoseDatum} from './parse-vehicle-pose';
 import {parseStreamPrimitive, parseStreamVariable, parseStreamFutures} from './parse-xviz-v1';
 import {parseStreamVideoMessage} from './parse-stream-video-message';
 


### PR DESCRIPTION
From the test data and `parse-xviz-v1` and `parse-xviz-v2`, expecting a single `variable` to be an object of `timestamps` and `values` pair

```
{
  "state_updates": [
    {
      "variables": {
        "/vehicle/commanded/velocity": {
          "timestamps": [
            123
          ],
          "type": "float",
          "values": [
            1.23
          ]
        }
      }
    }
  ]
}
```