### PR TITLE
Emacs specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 *~
 *.DS_Store
 .npmrc
+.dir-locals.el

--- a/ide/.dir-locals.el
+++ b/ide/.dir-locals.el
@@ -1,0 +1,10 @@
+;;; Emacs settings to adjust defaults to match this repository
+;;; use by manually symlinking this file from the root of the
+;;; repository.
+((nil . ((tab-width . 2)
+         (js-indent-level . 2)))
+
+ (js2-mode . ((tab-width . 2)
+             (js-indent-level . 2)))
+
+ (html-mode . ((tab-width . 2))))


### PR DESCRIPTION
I am not putting this in the root because other emacs users might
consider it invasive.  Instead we check it into a subfolder that an
emacs user can instead symlink too.

This is similar to what we do with vscode, but instead we actually
check the files in for others to share.