### PR TITLE
Schema checking code now reports parse errors by line

### DIFF
--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "ajv": "^6.5.2",
     "ajv-cli": "^3.0.0",
+    "jsonlint": "^1.6.3",
     "walk": "^2.3.14"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,6 +817,10 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+JSV@^4.0.x:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -5153,6 +5157,13 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonlint@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/jsonlint/-/jsonlint-1.6.3.tgz#cb5e31efc0b78291d0d862fbef05900adf212988"
+  dependencies:
+    JSV "^4.0.x"
+    nomnom "^1.5.x"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -5940,7 +5951,7 @@ node-releases@^1.0.0-alpha.11:
   dependencies:
     semver "^5.3.0"
 
-nomnom@^1.8.1:
+nomnom@^1.5.x, nomnom@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
   dependencies:


### PR DESCRIPTION
`JSON.parse` just returns an index, while `jsonlint` provides clear
erros so we integrate that.

The messages have tweaked to be like compiler errors so that it's
easier in a tool like emacs to click through to the problem line.