### PR TITLE
Correct setting for enableZOffset for the 'circle' xviz v1 primitive

### DIFF
--- a/modules/parser/src/parsers/xviz-primitives-v1.js
+++ b/modules/parser/src/parsers/xviz-primitives-v1.js
@@ -66,6 +66,7 @@ export default {
   },
   circle: {
     category: PRIMITIVE_CAT.FEATURE,
+    enableZOffset: true,
     validate: (primitive, streamName, time) => primitive.vertices && primitive.vertices.length > 0
   },
   circle2d: {


### PR DESCRIPTION
In PR (#16) a setting was lost in the v1 primitives that would flatten
points3d that are converted to circle if the streamName is not really
3d.

Specifically the file modules/parser/src/parsers/parse-xviz-v1.js
'circle: enableZOffset: true'

While the new file modules/parser/src/parsers/xviz-primitives-v1.js
lost the 'enableZOffset: true' part