### PR TITLE
Implement Buildkite for CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,26 @@
+steps:
+  - name: ":docker:"
+    plugins:
+      docker-compose#v1.5.2:
+        build: xviz
+        image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+
+  - wait
+
+  - name: ":eslint:"
+    command: "yarn lint"
+    plugins:
+      docker-compose#v1.5.2:
+        run: xviz
+
+  - name: ":node:"
+    command: "node test/start.js test src"
+    plugins:
+      docker-compose#v1.5.2:
+        run: xviz
+
+  - name: ":chrome:"
+    command: "sh /etc/init.d/xvfb && yarn test-browser"
+    plugins:
+      docker-compose#v1.5.2:
+        run: xviz

--- a/.buildkite/xvfb
+++ b/.buildkite/xvfb
@@ -1,0 +1,5 @@
+XVFB=/usr/bin/Xvfb
+XVFBARGS="$DISPLAY -screen 0 1024x768x24 -ac +extension GLX +render -noreset"
+PIDFILE=/var/run/xvfb.pid
+
+start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --background --exec $XVFB -- $XVFBARGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Docker Image for BuildKite CI
+# -----------------------------
+
+FROM node:8.11.4
+
+RUN yarn global add yarn@1.7.0
+
+WORKDIR /xviz
+ENV PATH /xviz/node_modules/.bin:$PATH
+
+ENV DISPLAY :99
+
+RUN apt-get update
+RUN apt-get -y install libxi-dev libgl1-mesa-dev xvfb
+
+ADD .buildkite/xvfb /etc/init.d/xvfb
+RUN chmod a+x /etc/init.d/xvfb
+
+COPY . /xviz/
+
+RUN yarn bootstrap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  xviz:
+    build: .


### PR DESCRIPTION
Implements a buildkite pipeline which builds a docker image, then runs the following tests in parallel:

* Linters
* Node tests
* Browser tests

This implements a pipeline which looks like:
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/122602/45405152-90392500-b616-11e8-8aed-553066bd18b3.png">

