### PR TITLE
Remove observeObjects config

### DIFF
--- a/modules/parser/src/config/xviz-config.js
+++ b/modules/parser/src/config/xviz-config.js
@@ -1,6 +1,9 @@
 import XvizPrimitiveSettingsV1 from '../parsers/xviz-primitives-v1';
 import XvizPrimitiveSettingsV2 from '../parsers/xviz-primitives-v2';
 
+import XvizObjectCollection from '../objects/xviz-object-collection';
+import XvizObject from '../objects/xviz-object';
+
 const DEFAULT_XVIZ_CONFIG = {
   // Config
   version: 2,
@@ -20,8 +23,7 @@ const DEFAULT_XVIZ_CONFIG = {
 
   // TODO - these are used at render time instead of parse time. Need API audit
   postProcessFrame: frame => frame, // Post process log frame, used in LogSlice.getCurrentFrame
-  getTrackedObjectPosition: _ => null,
-  observeObjects: () => {}
+  getTrackedObjectPosition: _ => null
 };
 
 const DEFAULT_XVIZ_SETTINGS = {
@@ -33,6 +35,8 @@ const DEFAULT_XVIZ_SETTINGS = {
 
 let xvizConfig = null;
 const xvizSettings = Object.assign({}, DEFAULT_XVIZ_SETTINGS);
+
+XvizObject.setDefaultCollection(new XvizObjectCollection());
 
 // CONFIG contains the static configuration of XVIZ (streams, how to postprocess etc)
 export function setXvizConfig(config) {

--- a/modules/parser/src/parsers/parse-xviz-stream.js
+++ b/modules/parser/src/parsers/parse-xviz-stream.js
@@ -1,5 +1,7 @@
 import {getXvizConfig} from '../config/xviz-config';
 import {normalizeXvizPrimitive} from './parse-xviz-primitive';
+import XvizObject from '../objects/xviz-object';
+import {isMainThread} from '../utils/globals';
 
 export const PRIMITIVE_CAT = {
   LOOKAHEAD: 'lookAheads',
@@ -60,13 +62,17 @@ export function parseXvizStream(data, convertPrimitive) {
  * data to UI elements.
  */
 export function parseStreamPrimitive(objects, streamName, time, convertPrimitive) {
-  const {observeObjects, preProcessPrimitive, PRIMITIVE_SETTINGS} = getXvizConfig();
+  const {OBJECT_STREAM, preProcessPrimitive, PRIMITIVE_SETTINGS} = getXvizConfig();
 
   if (!Array.isArray(objects)) {
     return {};
   }
 
-  observeObjects(streamName, objects, time);
+  if (isMainThread && streamName === OBJECT_STREAM) {
+    for (const object of objects) {
+      XvizObject.observe(object.id, time);
+    }
+  }
   const primitiveMap = createPrimitiveMap();
 
   let category = null;

--- a/modules/parser/src/utils/globals.js
+++ b/modules/parser/src/utils/globals.js
@@ -1,0 +1,2 @@
+/* global document */
+export const isMainThread = typeof document !== 'undefined';


### PR DESCRIPTION
- Remove custom `observeObjects` config. Call `XvizObject.observe` if stream name is `xvizConfig.OBJECT_STREAM`. (eventually should pull information from metadata)
- Perf: do not call `observe` on worker threads