### PR TITLE
Make XVIZMetadataBuilder produce correct array structured stylesheet …

### DIFF
--- a/modules/builder/src/builders/xviz-metadata-builder.js
+++ b/modules/builder/src/builders/xviz-metadata-builder.js
@@ -1,8 +1,17 @@
 // Note: XVIZ data structures use snake_case
 /* eslint-disable camelcase*/
 
+/* global console */
+/* eslint-disable no-console */
+const defaultValidateWarn = console.warn;
+const defaultValidateError = console.error;
+/* eslint-enable no-console */
+
 export default class XVIZMetadataBuilder {
-  constructor() {
+  constructor({validateWarn = defaultValidateWarn, validateError = defaultValidateError} = {}) {
+    this._validateWarn = validateWarn;
+    this._validateError = validateError;
+
     this.data = {
       streams: {},
       styles: {}
@@ -62,12 +71,20 @@ export default class XVIZMetadataBuilder {
   }
 
   styleClass(className, style) {
+    if (!this.stream_id) {
+      this._validateError('A stream must set before adding a style rule.');
+      return this;
+    }
+
+    const streamRule = {
+      ...style,
+      class: className
+    };
+
     if (!this.data.styles[this.stream_id]) {
-      this.data.styles[this.stream_id] = {
-        [className]: style
-      };
+      this.data.styles[this.stream_id] = [streamRule];
     } else {
-      this.data.styles[this.stream_id][className] = style;
+      this.data.styles[this.stream_id].push(streamRule);
     }
     return this;
   }

--- a/modules/parser/src/styles/stylesheet.js
+++ b/modules/parser/src/styles/stylesheet.js
@@ -7,12 +7,8 @@ const NULL_VALIDATOR = () => true;
 /* Parser for single stylesheet */
 export default class Stylesheet {
   constructor(data = []) {
-    const rules = (Array.isArray(data)
-      ? // Avoid mutating input data when calling reverse()
-        data.slice()
-      : // Backward compatibility - support classname to style map
-        Object.keys(data).map(classname => ({...data[classname], class: classname}))
-    )
+    const rules = data
+      .slice()
       // Newer rules override older ones
       .reverse()
       .map(rule => {

--- a/test/modules/builder/builders/xviz-metadata-builder.spec.js
+++ b/test/modules/builder/builders/xviz-metadata-builder.spec.js
@@ -31,3 +31,34 @@ test('XVIZMetadataBuilder#build', t => {
   t.deepEqual(metadata, expected, 'XVIZMetadataBuilder build matches expected output');
   t.end();
 });
+
+test('XVIZMetadataBuilder#stylesheet', t => {
+  const xb = new XVIZMetadataBuilder();
+  xb.stream('/test').styleClassDefault({
+    strokeColor: '#57AD57AA',
+    strokeWidth: 1.4,
+    strokeWidthMinPixels: 1
+  });
+
+  const metadata = xb.getMetadata();
+
+  const expected = {
+    type: 'metadata',
+    streams: {
+      '/test': {}
+    },
+    styles: {
+      '/test': [
+        {
+          class: '*',
+          strokeColor: '#57AD57AA',
+          strokeWidth: 1.4,
+          strokeWidthMinPixels: 1
+        }
+      ]
+    }
+  };
+
+  t.deepEqual(metadata, expected, 'XVIZMetadataBuilder build matches expected output');
+  t.end();
+});

--- a/test/modules/parser/styles/xviz-style-parser.spec.js
+++ b/test/modules/parser/styles/xviz-style-parser.spec.js
@@ -3,31 +3,6 @@ import tape from 'tape-catch';
 
 const TEST_STYLESHEETS = [
   {
-    title: 'Key-value map style (to be deprecated)',
-    stylesheet: {
-      '*': {
-        extruded: true,
-        height: 1.5,
-        strokeWidth: 1,
-        opacity: 0.5,
-        fillColor: '#808080'
-      },
-      'type=bike': {
-        fillColor: '#0000FF',
-        opacity: 1
-      },
-      'type=car tracked': {
-        strokeWidth: 3
-      },
-      tracked: {
-        fillColor: '#FFFF00'
-      },
-      fancy: {
-        fillColor: '#101010'
-      }
-    }
-  },
-  {
     title: 'Array style',
     stylesheet: [
       {


### PR DESCRIPTION
…rules

- fix metadata builder to use current stylesheet array structure
- remove support for deprecated stylesheet dictionary structure
- add test case for XVIZMetadataBuilder stylesheet structure