### PR TITLE
Update spec to associate variable & time series with objects

### DIFF
--- a/docs/protocol-schema/core-protocol.md
+++ b/docs/protocol-schema/core-protocol.md
@@ -181,9 +181,11 @@ An example of this would be planning data as a function of time over the next 10
 
 Each stream would contain the same number of values and then the velocity and jerk streams could be plotted as a function of the time stream. For more details on how to plot see the UI Metadata section.
 
-| Name     | Type           | Description |
-| ---      | ---            | --- |
-| `values` | `list<values>` | The values |
+| Name     | Type                      | Description |
+| ---      | ---                       | --- |
+| `values`    | `list<values>`         | The values |
+| `object_id` | `optional<object_id>`  | Associated object, optional |
+
 
 As an example a complete [`stream_set`](/docs/protocol-schema/core-protocol.md#stream-set), containing the above variables would look like:
 
@@ -202,7 +204,7 @@ This models a set of values that changes each time a data is transformed. These 
 | ---         | ---                        | --- |
 | `timestamp` | `timestamp`                | The vehicle/log transmission\_time associated with this data. |
 | `values`    | `list<{stream_id, value}>` | Number/string/whatever |
-| `id`        | `optional<object_id>`      | Associated object, optional |
+| `object_id` | `optional<object_id>`      | Associated object, optional |
 
 Here is an example `time_series_state` for a system producing multiple values at a specific time:
 

--- a/modules/schema/core/timeseries_state.schema.json
+++ b/modules/schema/core/timeseries_state.schema.json
@@ -25,6 +25,9 @@
         "additionalItems": false
       },
       "additionalItems": false
+    },
+    "object_id": {
+      "type": "string"
     }
   },
   "required": [ "timestamp", "values" ],

--- a/modules/schema/core/variable_state.schema.json
+++ b/modules/schema/core/variable_state.schema.json
@@ -10,6 +10,9 @@
         "$ref": "https://xviz.org/schema/core/value.schema.json"
       },
       "additionalItems": false
+    },
+    "object_id": {
+      "type": "string"
     }
   },
   "required": [

--- a/modules/schema/examples/core/timeseries_state/with_object_id.json
+++ b/modules/schema/examples/core/timeseries_state/with_object_id.json
@@ -1,0 +1,8 @@
+{
+    "timestamp": 12345.5,
+    "values": [
+        ["/vehicle/torque/commanded", 5],
+        ["/vehicle/torque/actual", 4.8]
+    ],
+    "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}"
+}

--- a/modules/schema/examples/core/variable_state/with_object_id.json
+++ b/modules/schema/examples/core/variable_state/with_object_id.json
@@ -1,0 +1,5 @@
+{
+  "name": "/plan/time",
+  "values": [1001.3, 1002.3, 1003.3],
+  "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}"
+}


### PR DESCRIPTION
This was an oversight in the earlier part of the specification.  All
XVIZ elements should be able to associate with objects so you can
properly cross reference different data sources.

This is the specification and docs part of #106 