### PR TITLE
Add 'options' parameter to XVIZWriter to control the format of the output

### DIFF
--- a/modules/builder/package.json
+++ b/modules/builder/package.json
@@ -14,9 +14,10 @@
     "src"
   ],
   "dependencies": {
-    "text-encoding": "^0.6.4",
     "@turf/turf": "^5.1.6",
-    "math.gl": "^2.0.0"
+    "base64-js": "^1.3.0",
+    "math.gl": "^2.0.0",
+    "text-encoding": "^0.6.4"
   },
   "scripts": {
     "clean": "rm -fr dist && mkdir -p dist",

--- a/modules/builder/src/writers/xviz-writer/xviz-json-encoder.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-json-encoder.js
@@ -1,0 +1,54 @@
+import base64js from 'base64-js';
+
+// Recursively walk object performing the following conversions
+// - primitives with typed array fields are turned into arrays
+// - primtives of type image have the data turned into a base64 string
+export function xvizConvertJson(object, keyName) {
+  if (Array.isArray(object)) {
+    return object.map(element => xvizConvertJson(element));
+  }
+
+  // Typed arrays become normal arrays
+  // TODO: no way to know if this should be 3 or 4
+  if (ArrayBuffer.isView(object)) {
+    // Return normal arrays
+    if (keyName !== 'vertices') {
+      return Array.from(object);
+    }
+
+    // For primitives with key's 'vertices', we force nested arrays.
+    // TODO(twojtasz): Support flat arrays
+    const length = object.length;
+    if (length % 3 !== 0) {
+      throw new Error('TypeArray conversion failure. The array is expect to be divisible by 3');
+    }
+
+    // Construct points from flattened array
+    const newObject = [];
+    const count = length / 3;
+    for (let i = 0; i < count; i++) {
+      newObject.push(Array.from(object.slice(i * 3, i * 3 + 3)));
+    }
+    return newObject;
+  }
+
+  if (object !== null && typeof object === 'object') {
+    // Handle XVIZ Image Primitive
+    const properties = Object.keys(object);
+    if (['type', 'data'].every(prop => properties.includes(prop)) && object.type === 'image') {
+      return {
+        ...object,
+        data: base64js.fromByteArray(object.data)
+      };
+    }
+
+    // Handle all other objects
+    const newObject = {};
+    for (const key in object) {
+      newObject[key] = xvizConvertJson(object[key], key);
+    }
+    return newObject;
+  }
+
+  return object;
+}

--- a/modules/builder/src/writers/xviz-writer/xviz-writer.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-writer.js
@@ -1,22 +1,52 @@
 import {writeBinaryXVIZtoFile} from './xviz-binary-writer';
+import {xvizConvertJson} from './xviz-json-encoder.js';
 
 export default class XVIZWriter {
   // xvizMetadata is the object returned
   // from a Builder.
-  writeMetadata(xvizDirectory, xvizMetadata) {
+  writeMetadata(xvizDirectory, xvizMetadata, options = {writeBinary: true, writeJson: false}) {
     const fs = module.require('fs');
     const path = module.require('path');
     const xvizMetadataFilename = path.join(xvizDirectory, '1-frame');
-    writeBinaryXVIZtoFile(xvizMetadataFilename, xvizMetadata, {flattenArrays: false});
-    fs.writeFileSync(`${xvizMetadataFilename}.json`, JSON.stringify(xvizMetadata, null, 2), {
-      flag: 'w'
-    });
+    if (options.writeBinary) {
+      writeBinaryXVIZtoFile(xvizMetadataFilename, xvizMetadata, {flattenArrays: false});
+    }
+
+    if (options.writeJson) {
+      fs.writeFileSync(`${xvizMetadataFilename}.json`, JSON.stringify(xvizMetadata, null, 2), {
+        flag: 'w'
+      });
+    }
   }
 
-  writeFrame(xvizDirectory, frameNumber, xvizFrame) {
+  writeFrame(
+    xvizDirectory,
+    frameNumber,
+    xvizFrame,
+    options = {writeBinary: true, writeJson: false, precision: 9}
+  ) {
+    const fs = module.require('fs');
     const path = module.require('path');
     // +2 is because 1 is metadata, so we start with 2
     const frameFilePath = path.join(xvizDirectory, `${frameNumber + 2}-frame`);
-    writeBinaryXVIZtoFile(frameFilePath, xvizFrame, {flattenArrays: false});
+    if (options.writeBinary) {
+      writeBinaryXVIZtoFile(frameFilePath, xvizFrame, {flattenArrays: false});
+    }
+
+    if (options.writeJson) {
+      // Limit precision to save space
+      const numberRounder = (k, value) => {
+        if (typeof value === 'number') {
+          return Number(value.toFixed(options.precision));
+        }
+
+        return value;
+      };
+
+      const jsonXvizFrame = xvizConvertJson(xvizFrame);
+      fs.writeFileSync(`${frameFilePath}.json`, JSON.stringify(jsonXvizFrame, numberRounder), {
+        flag: 'w'
+      });
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,7 +2815,7 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
@@ -9147,13 +9147,13 @@ test-exclude@^5.0.0:
     read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
-text-extensions@^1.0.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.8.0.tgz#6f343c62268843019b21a616a003557bdb952d2b"
-
 text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
+text-extensions@^1.0.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.8.0.tgz#6f343c62268843019b21a616a003557bdb952d2b"
 
 text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Binary is default. JSON has the following changes:
- typed arrays are converted to arrays
- typed arrays for primitive's with a key 'vertices' are turned into
  nested arrays
- images are converted to base64 strings
- all Number values in the JSON are fixed to a precision of 6 decimal
  places. This is to save on file size