### PR TITLE
Clean up XvizStreamBuffer class

### DIFF
--- a/modules/parser/src/constants.js
+++ b/modules/parser/src/constants.js
@@ -15,11 +15,3 @@ export const LOG_STREAM_MESSAGE = {
   ERROR: 'ERROR',
   INCOMPLETE: 'INCOMPLETE'
 };
-
-// TODO/OSS - is this generic enough
-// These are bit flags that marks the completeness of a time slice
-export const STREAM_DATA_CONTENT = {
-  VEHICLE: 1,
-  XVIZ: 2,
-  ALL: 3
-};

--- a/modules/parser/src/index.js
+++ b/modules/parser/src/index.js
@@ -4,7 +4,7 @@ export {default as xvizStats} from './utils/stats';
 // GENERIC XVIZ EXPORTS
 
 // Common constants
-export {LOG_STREAM_MESSAGE, STREAM_DATA_CONTENT} from './constants';
+export {LOG_STREAM_MESSAGE} from './constants';
 
 // Configuration
 export {setXvizConfig, getXvizConfig, setXvizSettings, getXvizSettings} from './config/xviz-config';

--- a/modules/parser/src/parsers/parse-stream-data-message.js
+++ b/modules/parser/src/parsers/parse-stream-data-message.js
@@ -5,7 +5,7 @@
  * `data` refers to pre-processed data objects (blob, arraybuffer, JSON object)
  */
 /* global Blob, Uint8Array */
-import {LOG_STREAM_MESSAGE, STREAM_DATA_CONTENT} from '../constants';
+import {LOG_STREAM_MESSAGE} from '../constants';
 import {getXvizConfig} from '../config/xviz-config';
 import {parseBinaryXVIZ, isBinaryXVIZ} from '../loaders/xviz-loader/xviz-binary-loader';
 import {parseLogMetadata} from './parse-log-metadata';
@@ -106,9 +106,7 @@ function parseTimesliceData(data, convertPrimitive) {
     type: LOG_STREAM_MESSAGE.TIMESLICE,
     streams: newStreams,
     channels: newStreams, // TODO -remove, backwards compatibility
-    timestamp,
-    missingContentFlags:
-      (!stateUpdates && STREAM_DATA_CONTENT.XVIZ) | (!vehiclePose && STREAM_DATA_CONTENT.VEHICLE)
+    timestamp
   };
 
   if (stateUpdates) {

--- a/test/modules/parser/synchronizers/xviz-stream-buffer.spec.js
+++ b/test/modules/parser/synchronizers/xviz-stream-buffer.spec.js
@@ -1,6 +1,6 @@
 import test from 'tape-catch';
 
-import {XvizStreamBuffer, STREAM_DATA_CONTENT} from '@xviz/parser';
+import {XvizStreamBuffer} from '@xviz/parser';
 
 const TEST_TIMESLICES = [
   {
@@ -49,7 +49,7 @@ test('XvizStreamBuffer#constructor', t => {
     endOffset: 5
   });
   t.ok(xvizStreamBufferLimited instanceof XvizStreamBuffer, 'constructor does not throw error');
-  t.ok(xvizStreamBufferLimited.isOffsetLimited, 'buffer is limited');
+  t.is(xvizStreamBufferLimited.bufferType, 1, 'buffer is limited');
 
   t.throws(() => new XvizStreamBuffer({startOffset: 1, endOffset: 5}), 'validates parameters');
 
@@ -66,38 +66,6 @@ test('XvizStreamBuffer#getLoadedTimeRange', t => {
     {start: 1001, end: 1005},
     'returns correct buffer range'
   );
-
-  t.end();
-});
-
-test('XvizStreamBuffer#getLoadedTimeRange - partial timeslices', t => {
-  const testPartialTimeslices = [
-    {timestamp: 1000.0, missingContentFlags: STREAM_DATA_CONTENT.VEHICLE},
-    {timestamp: 1000.04, missingContentFlags: STREAM_DATA_CONTENT.XVIZ},
-    {timestamp: 1000.1, missingContentFlags: STREAM_DATA_CONTENT.VEHICLE},
-    {timestamp: 1000.14, missingContentFlags: STREAM_DATA_CONTENT.XVIZ},
-    {timestamp: 1000.2, missingContentFlags: STREAM_DATA_CONTENT.VEHICLE},
-    {timestamp: 1000.24, missingContentFlags: STREAM_DATA_CONTENT.XVIZ},
-    {timestamp: 1000.3, missingContentFlags: STREAM_DATA_CONTENT.VEHICLE},
-    {timestamp: 1000.34, missingContentFlags: STREAM_DATA_CONTENT.XVIZ}
-  ];
-  const testCases = [
-    null,
-    {start: 1000.04, end: 1000.04},
-    {start: 1000.04, end: 1000.04},
-    {start: 1000.04, end: 1000.14},
-    {start: 1000.04, end: 1000.14},
-    {start: 1000.04, end: 1000.24},
-    {start: 1000.04, end: 1000.24},
-    {start: 1000.04, end: 1000.34}
-  ];
-
-  const xvizStreamBuffer = new XvizStreamBuffer();
-
-  testCases.forEach((result, i) => {
-    xvizStreamBuffer.timeslices = testPartialTimeslices.slice(0, i + 1);
-    t.deepEquals(xvizStreamBuffer.getLoadedTimeRange(), result, 'returns correct buffer range');
-  });
 
   t.end();
 });
@@ -224,7 +192,7 @@ test('XvizStreamBuffer#updateFixedBuffer contraction, removes invalid data', t =
 
   t.ok(xvizStreamBuffer.hasBuffer(1002, 1003), 'returns true for new range');
   t.ok(!xvizStreamBuffer.hasBuffer(1001, 1004), 'returns false for outside of range');
-  t.ok(xvizStreamBuffer.isFixedLimited, 'buffer is limited');
+  t.is(xvizStreamBuffer.bufferType, 2, 'buffer is limited');
   t.end();
 });
 
@@ -237,7 +205,7 @@ test('XvizStreamBuffer#updateFixedBuffer uncapped expansion', t => {
   t.is(end, 1010, 'expands buffer end');
   t.is(oldStart, 1002, 'returns old buffer start');
   t.is(oldEnd, 1004, 'returns old buffer end');
-  t.ok(xvizStreamBuffer.isFixedLimited, 'buffer is limited');
+  t.is(xvizStreamBuffer.bufferType, 2, 'buffer is limited');
   t.end();
 });
 


### PR DESCRIPTION
- Remove logic that handles incomplete timeslices (no longer needed internally, doesn't really work anyways)
- Consolidate `isOffsetLimited` and `isFixedLimited` to `bufferType` (breaking)