### PR TITLE
Change to more compatible draft-04 JSON schema

### DIFF
--- a/modules/schema/core/_primitive_list.schema.json
+++ b/modules/schema/core/_primitive_list.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/_primitive_list.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/_primitive_list.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Internal XVIZ primitive list",
   "type": "array",
   "items": {

--- a/modules/schema/core/annotation_base.schema.json
+++ b/modules/schema/core/annotation_base.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/annotation_base.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/annotation_base.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "object_id": {

--- a/modules/schema/core/annotation_visual.schema.json
+++ b/modules/schema/core/annotation_visual.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/annotation_visual.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/annotation_visual.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Visual Annotation",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/annotation_base.json" }],
   "properties": {

--- a/modules/schema/core/future_instances.schema.json
+++ b/modules/schema/core/future_instances.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/future_instances.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/future_instances.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Future Instances",
   "type": "object",
   "properties": {

--- a/modules/schema/core/primitive_base.schema.json
+++ b/modules/schema/core/primitive_base.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/primitive_base.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/primitive_base.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "type": {

--- a/modules/schema/core/primitive_state.schema.json
+++ b/modules/schema/core/primitive_state.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/primitive_state.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/primitive_state.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Primitive State",
   "type": "object",
   "properties": {

--- a/modules/schema/core/stream_set.schema.json
+++ b/modules/schema/core/stream_set.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/stream_set.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/stream_set.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Stream set",
   "type": "object",
   "properties": {

--- a/modules/schema/core/timeseries_state.schema.json
+++ b/modules/schema/core/timeseries_state.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/timeseries_state.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/timeseries_state.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Timeseries State",
   "type": "object",
   "properties": {

--- a/modules/schema/core/value.schema.json
+++ b/modules/schema/core/value.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/value.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/value.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Value",
   "oneOf": [
     {"type": "number"},

--- a/modules/schema/core/variable.schema.json
+++ b/modules/schema/core/variable.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/variable.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/variable.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Variable State",
   "type": "object",
   "properties": {

--- a/modules/schema/core/variable_state.schema.json
+++ b/modules/schema/core/variable_state.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/core/variable_state.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/core/variable_state.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Variable State",
   "type": "object",
   "properties": {

--- a/modules/schema/math/matrix3x3.schema.json
+++ b/modules/schema/math/matrix3x3.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/math/matrix3x3.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/math/matrix3x3.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point primitive",
   "type": "array",
   "items": {

--- a/modules/schema/math/matrix4x4.schema.json
+++ b/modules/schema/math/matrix4x4.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/math/matrix4x4.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/math/matrix4x4.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point primitive",
   "type": "array",
   "items": {

--- a/modules/schema/math/point3d_list.schema.json
+++ b/modules/schema/math/point3d_list.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/math/point3d_list.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/math/point3d_list.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point 3D list",
   "oneOf": [
     {

--- a/modules/schema/math/vector3x1.schema.json
+++ b/modules/schema/math/vector3x1.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/math/vector3x1.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/math/vector3x1.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point primitive",
   "type": "array",
   "items": {

--- a/modules/schema/primitives/circle.schema.json
+++ b/modules/schema/primitives/circle.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/circle.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/circle.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/primitives/image.schema.json
+++ b/modules/schema/primitives/image.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/image.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/image.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Image primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/primitives/point.schema.json
+++ b/modules/schema/primitives/point.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/point.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/point.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/primitives/polygon.schema.json
+++ b/modules/schema/primitives/polygon.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/polygon.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/polygon.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Polygon primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/primitives/polyline.schema.json
+++ b/modules/schema/primitives/polyline.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/polyline.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/polyline.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Polyline primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/primitives/stadium.schema.json
+++ b/modules/schema/primitives/stadium.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/stadium.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/stadium.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Point primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/primitives/text.schema.json
+++ b/modules/schema/primitives/text.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/primitives/text.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/primitives/text.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Text primitive",
   "allOf": [{ "$ref": "https://xviz.org/schema/core/primitive_base.json" }],
   "properties": {

--- a/modules/schema/session/camera_info.schema.json
+++ b/modules/schema/session/camera_info.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/session/camera_info.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/session/camera_info.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Camera Information",
   "type": "object",
   "properties": {

--- a/modules/schema/session/metadata.schema.json
+++ b/modules/schema/session/metadata.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/session/metadata.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/session/metadata.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Session Metadata",
   "type": "object",
   "properties": {

--- a/modules/schema/session/start.schema.json
+++ b/modules/schema/session/start.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/session/start.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/session/start.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Session Start",
   "type": "object",
   "properties": {

--- a/modules/schema/session/state_update.schema.json
+++ b/modules/schema/session/state_update.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/session/state_update.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/session/state_update.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Stream Update",
   "type": "object",
   "properties": {

--- a/modules/schema/session/stream_metadata.schema.json
+++ b/modules/schema/session/stream_metadata.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/session/stream_metadata.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/session/stream_metadata.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Stream Metadata",
   "type": "object",
   "properties": {
@@ -48,6 +48,5 @@
       "required": ["transform"]
     }
   ],
-  "required": [],
   "additionalProperties": false
 }

--- a/modules/schema/session/ui_panel_info.schema.json
+++ b/modules/schema/session/ui_panel_info.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/session/ui_panel_info.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/session/ui_panel_info.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Session UI Panel Info",
   "type": "object",
   "properties": {

--- a/modules/schema/src/index.js
+++ b/modules/schema/src/index.js
@@ -11,21 +11,25 @@ import {parse as jsonlintParse} from 'jsonlint';
 const Ajv = require('ajv');
 
 export function validateExampleFiles(schemaDir, examplesDir) {
-  const validator = new Ajv();
+  const validator = newAjv();
 
   let valid = loadAllSchemas(validator, schemaDir);
 
-  valid = valid & validateFiles(validator, examplesDir, true);
+  if (valid) {
+    valid = validateFiles(validator, examplesDir, true);
+  }
 
   return valid;
 }
 
 export function validateInvalidFiles(schemaDir, invalidDir) {
-  const validator = new Ajv();
+  const validator = newAjv();
 
   let valid = loadAllSchemas(validator, schemaDir);
 
-  valid = valid & validateFiles(validator, invalidDir, false);
+  if (valid) {
+    valid = validateFiles(validator, invalidDir, false);
+  }
 
   return valid;
 }
@@ -35,6 +39,32 @@ class ParseError extends Error {
     super(...args);
     Error.captureStackTrace(this, ParseError);
   }
+}
+
+function newAjv() {
+  const validator = newAjvDraft4();
+  return validator;
+}
+
+// Draft 4 schema is more widely supported, but requires special
+// construction
+function newAjvDraft4() {
+  const ajv = new Ajv({
+    meta: false, // Prevent loading future schemas
+    schemaId: 'id', // needed because we use 'id' in draft-04
+    extendRefs: 'fail' // Be more strict, don't allow ref extension
+  });
+
+  const metaSchema = require('ajv/lib/refs/json-schema-draft-04.json');
+  ajv.addMetaSchema(metaSchema);
+  ajv._opts.defaultMeta = metaSchema.id;
+
+  // Disable keywords defined in future drafts
+  ajv.removeKeyword('propertyNames');
+  ajv.removeKeyword('contains');
+  ajv.removeKeyword('const');
+
+  return ajv;
 }
 
 function loadAllSchemas(validator, schemaDir) {
@@ -130,7 +160,9 @@ function validateFile(validator, examplesDir, examplePath, expectGood) {
   }
 
   if (validate === undefined) {
-    console.log(`While checking: ${examplePath}, failed to load: ${schemaRelPath}`);
+    console.log(
+      `ERROR: While checking: ${examplePath}, failed to load: ${schemaRelPath} and: ${directorySchema}`
+    );
     return false;
   }
 

--- a/modules/schema/style/_color.schema.json
+++ b/modules/schema/style/_color.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/style/_color.schema.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/style/_color.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Internal XVIZ RGBA color type",
   "oneOf": [
     {

--- a/modules/schema/style/class.schema.json
+++ b/modules/schema/style/class.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/style/class.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/style/class.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Style Class",
   "type": "object",
   "properties": {

--- a/modules/schema/style/object_value.schema.json
+++ b/modules/schema/style/object_value.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/style/object_value.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/style/object_value.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Object Style Value",
   "type": "object",
   "properties": {

--- a/modules/schema/style/stream_value.schema.json
+++ b/modules/schema/style/stream_value.schema.json
@@ -1,6 +1,6 @@
 {
-  "$id": "https://xviz.org/schema/style/stream_value.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "id": "https://xviz.org/schema/style/stream_value.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "XVIZ Stream Style Value",
   "type": "object",
   "properties": {

--- a/test/modules/schema/data/schema/example.schema.json
+++ b/test/modules/schema/data/schema/example.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Example schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
C++ and Python implementations of JSON schema are lagging behind a bit
so draft-04 is the most widely supported right now.  We also do not
use any of the newer features so we are safe to use the old spec.