### PR TITLE
Fix schema to allow multiple annotations on a single stream

### DIFF
--- a/modules/schema/core/_annotation_list.schema.json
+++ b/modules/schema/core/_annotation_list.schema.json
@@ -1,0 +1,12 @@
+{
+  "id": "https://xviz.org/schema/core/_annotation_list.schema.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Internal XVIZ annotation list",
+  "type": "array",
+  "items": {
+    "anyOf": [
+      {"$ref": "https://xviz.org/schema/core/annotation_visual.json"}
+    ]
+  },
+  "additionalItems": false
+}

--- a/modules/schema/core/annotation_state.schema.json
+++ b/modules/schema/core/annotation_state.schema.json
@@ -1,0 +1,15 @@
+{
+  "id": "https://xviz.org/schema/core/annotation_state.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "XVIZ Annotation State",
+  "type": "object",
+  "properties": {
+    "annotations": {
+      "$ref": "https://xviz.org/schema/core/_annotation_list.schema.json"
+    }
+  },
+  "required": [
+    "annotations"
+  ],
+  "additionalProperties": false
+}

--- a/modules/schema/core/stream_set.schema.json
+++ b/modules/schema/core/stream_set.schema.json
@@ -36,9 +36,7 @@
     "annotations": {
       "type": "object",
       "additionalProperties": {
-        "oneOf": [
-          {"$ref": "https://xviz.org/schema/core/annotation_visual.json"}
-        ]
+        "$ref": "https://xviz.org/schema/core/annotation_state.json"
       }
     }
   },

--- a/modules/schema/examples/core/annotation_state/double.json
+++ b/modules/schema/examples/core/annotation_state/double.json
@@ -1,0 +1,22 @@
+{
+  "annotations": [
+    {
+      "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}",
+      "style_classes": [
+        "highlighted"
+      ],
+      "inline_style": {
+        "fill_color": [255, 0, 0, 255]
+      }
+    },
+    {
+      "object_id": "{317d719e-f95a-49a7-91fc-3706b2eeb5c2}",
+      "style_classes": [
+        "unimportant"
+      ],
+      "inline_style": {
+        "fill_color": [10, 10, 10, 255]
+      }
+    }
+  ]
+}

--- a/modules/schema/examples/core/annotation_state/single.json
+++ b/modules/schema/examples/core/annotation_state/single.json
@@ -1,0 +1,13 @@
+{
+  "annotations": [
+    {
+      "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}",
+      "style_classes": [
+        "highlighted"
+      ],
+      "inline_style": {
+        "fill_color": [255, 0, 0, 255]
+      }
+    }
+  ]
+}

--- a/modules/schema/examples/core/annotation_visual.json
+++ b/modules/schema/examples/core/annotation_visual.json
@@ -1,5 +1,5 @@
 {
-  "object_id": "122",
+  "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}",
   "style_classes": [
     "highlighted"
   ],

--- a/modules/schema/examples/core/stream_set/complete.json
+++ b/modules/schema/examples/core/stream_set/complete.json
@@ -144,13 +144,26 @@
   },
   "annotations": {
     "/object/highlights": {
-      "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}",
-      "style_classes": [
-        "highlighted"
-      ],
-      "inline_style": {
-        "fill_color": [255, 0, 0, 255]
-      }
+      "annotations": [
+        {
+          "object_id": "{067a2faf-64b5-4b8f-8d7d-ed873630df4f}",
+          "style_classes": [
+            "highlighted"
+          ],
+          "inline_style": {
+            "fill_color": [255, 0, 0, 255]
+          }
+        },
+        {
+          "object_id": "{317d719e-f95a-49a7-91fc-3706b2eeb5c2}",
+          "style_classes": [
+            "unimportant"
+          ],
+          "inline_style": {
+            "fill_color": [10, 10, 10, 255]
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This allows a stream like `/objects/important` to contain a list of
annotations one for each object in that stream considered "important"
adding a style class like `important`.  Previously we could only have
one annotation per stream, limiting their usefulness.

From a schema standpoint this mirrors the primitive setup with an
internal list type.