### PR TITLE
Move pose to explicit location in stream_set in spec & docs (#125)

### DIFF
--- a/docs/protocol-schema/core-protocol.md
+++ b/docs/protocol-schema/core-protocol.md
@@ -28,6 +28,27 @@ As an example, the stream `/object/shape` would contain all primitive shapes, wh
 Since the representation for an object is split across streams, XVIZ base types can have an ID which will be used to maintain the relationship of the data. In the example above, the /shape stream would transmit the object’s shape information, while the /velocity stream would transmit the object’s velocity information. These streams are separated for ease of parsing and improved data compression - for example, object shapes may only need to be updated once per second, whereas velocities might be more useful updated 10 times per second.
 
 
+
+### Poses
+
+A core part of XVIZ is knowing the location of the vehicle(s) so they can be displayed relative to the other data. This defines the location of the vehicle from it's own arbitrary frame, along with it's location in latitude, longitude, form.
+
+| Name           | Type               | Description |
+| ---            | ---                | --- |
+| `timestamp`    | `float`            | The vehicle/log transmission\_time associated with this data. |
+| `mapOrigin`    | `map_origin`       | Uniquely identifies an object for all time. |
+| `position`     | `array<float>(3)`  | x, y, z position in meters |
+| `orientation`  | `array<float>(3)`  | roll, pitch, yaw angle in radians  |
+
+The `map_origin` object describes a location in geographic coordinates and altitude:
+
+| Name        | Type     | Description |
+| ---         | ---      | --- |
+| `longitude` | `float`  | The east-west geographic coordinate in degrees |
+| `latitude`  | `float`  | The north-south geographic coordinate in degrees |
+| `altitude`  | `float`  | The altitude above sea level in meters |
+
+
 ### Styles
 
 Similar to CSS each primitive can have one or more classes, each of which can have associated style information.  This allows the styling information to be sent out of band with the main data flows, and only once.  Learn more in the [style specification](/docs/protocol-schema/style-specification.md).
@@ -88,7 +109,8 @@ This is a single cohesive set of streams which all happened at the same time and
 | ---             | ---                                 | --- |
 | `timestamp`     | `timestamp`                         | The vehicle/log transmission\_time associated with this data. |
 | `primitives`    | `map<stream_id, primitive_state>`   | Streams containing list of primitives.  |
-| `time_series`   | `list<time_series_state>` |   |
+| `poses`         | `list<pose>`                        | Related vehicle poses  |
+| `time_series`   | `list<time_series_state>`           |   |
 | `future_states` | `map<stream_id, future_instances>`  | Streams containing This represents a collection of primitives at different timestamps, for the current stream set timestamp  |
 | `variables`     | `map<stream_id, variable_state>`    | Streams containing list of values.  |
 | `annotations`   | `map<stream_id, annotation_state>`  | Streams containing annotations  |

--- a/modules/schema/core/pose.schema.json
+++ b/modules/schema/core/pose.schema.json
@@ -1,0 +1,51 @@
+{
+  "id": "https://xviz.org/schema/core/pose.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "type": "number",
+      "minimum": 0
+    },
+    "mapOrigin": {
+      "type": "object",
+      "properties": {
+        "longitude": {
+          "type": "number"
+        },
+        "latitude": {
+          "type": "number"
+        },
+        "altitude": {
+          "type": "number"
+        }
+      },
+      "required": [ "longitude", "latitude", "altitude" ],
+      "additionalProperties": false
+    },
+    "position": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "additionalItems": false
+    },
+    "orientation": {
+      "type": "array",
+      "items": {
+        "type": "number"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "additionalItems": false
+    }
+  },
+  "required": [
+    "timestamp",
+    "position",
+    "orientation"
+  ],
+  "additionalProperties": true
+}

--- a/modules/schema/core/stream_set.schema.json
+++ b/modules/schema/core/stream_set.schema.json
@@ -7,6 +7,18 @@
     "timestamp": {
       "type": "number"
     },
+    "poses": {
+      "type": "object",
+      "properties": {
+        "/vehicle_pose": {
+          "$ref": "https://xviz.org/schema/core/pose.json"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "https://xviz.org/schema/core/pose.json"
+      },
+      "required": [ "/vehicle_pose" ]
+    },
     "primitives": {
       "type": "object",
       "additionalProperties": {

--- a/modules/schema/examples/core/pose/extrafields.json
+++ b/modules/schema/examples/core/pose/extrafields.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": 1001.3,
+  "mapOrigin": {
+    "longitude": 40.4641969,
+    "latitude": -79.9733218,
+    "altitude": 219
+  },
+  "position": [238.4, 1002.5, 5.0],
+  "orientation": [0.5, 10.0, 84.5],
+  "id": "3e0d881a-3c2a-4372-8428-c54a22c54290"
+}

--- a/modules/schema/examples/core/pose/normal.pose
+++ b/modules/schema/examples/core/pose/normal.pose
@@ -1,0 +1,10 @@
+{
+  "timestamp": 1001.3,
+  "mapOrigin": {
+    "longitude": 40.4641969,
+    "latitude": -79.9733218,
+    "altitude": 219
+  },
+  "position": [238.4, 1002.5, 5.0],
+  "orientation": [0.5, 10.0, 84.5]
+}

--- a/modules/schema/examples/core/stream_set/primitives_and_poses.json
+++ b/modules/schema/examples/core/stream_set/primitives_and_poses.json
@@ -1,0 +1,34 @@
+{
+  "timestamp": 1001.3,
+  "poses": {
+    "/vehicle_pose": {
+      "timestamp": 1001.3,
+      "mapOrigin": {
+        "longitude": 40.4641969,
+        "latitude": -79.9733218,
+        "altitude": 219
+      },
+      "position": [238.4, 1002.5, 5.0],
+      "orientation": [0.5, 10.0, 84.5]
+    },
+    "/original/vehicle_pose": {
+      "timestamp": 1001.3,
+      "mapOrigin": {
+        "longitude": 40.46423,
+        "latitude": -79.97384,
+        "altitude": 220
+      },
+      "position": [123.4, 578.1, 3.5],
+      "orientation": [1.5, 95.0, 24.5]
+    }
+  },
+  "primitives": {
+    "/object/points": {
+      "primitives": [
+        {
+          "points": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
+        }
+      ]
+    }
+  }
+}

--- a/modules/schema/examples/core/stream_set/primitives_only.json
+++ b/modules/schema/examples/core/stream_set/primitives_only.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": 1001.3,
+  "primitives": {
+    "/object/points": {
+      "primitives": [
+        {
+          "points": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
A core part of XVIZ is knowing the location of the vehicle(s) so they
can be displayed relative to the other data.  This explicitly
specifies how to pass that data along and what format it comes in.

We are adding a `poses` map to the `stream_set` object, which already
contains all the core data like primitives and time series data. By
default if the `poses` field is present it must contain the default
pose stream `/vehicle_pose`.

Each field of that map contains the raw position and orientation of
the vehicle as well as a mapOrigin.

As seen in the discussions in #112 and #113.