### PR TITLE
Lint & format website and part of docs with prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,3 +3,4 @@ semi: true
 singleQuote: true
 trailingComma: none
 bracketSpacing: false
+proseWrap: always

--- a/docs/overview/concepts.md
+++ b/docs/overview/concepts.md
@@ -2,71 +2,72 @@
 
 The description of the XVIZ protocol is based a number of concepts that are introduced here.
 
-
 ## Datum
 
 A data object (typically from a robotics system) that we wish to visualize.
 
-
 ## Stream
 
-A stream is a sequence of timestamped datums of the same type. Different types of datums are organized in different streams.
+A stream is a sequence of timestamped datums of the same type. Different types of datums are
+organized in different streams.
 
-* **Stream Name** - Each stream must be given a unique name. The application defines these names, XVIZ requires the names follow a path-like structure separated by '/', such as '/vehicle/velocity'.
-* **Stream Type** - The type of a stream is defined by what kind of datums it contains.
+- **Stream Name** - Each stream must be given a unique name. The application defines these names,
+  XVIZ requires the names follow a path-like structure separated by '/', such as
+  '/vehicle/velocity'.
+- **Stream Type** - The type of a stream is defined by what kind of datums it contains.
 
-The following stream types are predefined by the protocol, and the XVIZ client library contains support for parsing and displaying them:
+The following stream types are predefined by the protocol, and the XVIZ client library contains
+support for parsing and displaying them:
 
-* **Pose Stream** - A set of positions that describes the position and orientaton of an actor and any relative coordinate system(s) it defines.
-* **Geometry Types** - geometry primitives
-* **Variables** - arrays of data
-* **Time series** - individual samples of a larger series
-* **Tree Table** - hierarchical data structure, use to convey dense record type data
-* **Image Stream** - Binary format image data
-
+- **Pose Stream** - A set of positions that describes the position and orientaton of an actor and
+  any relative coordinate system(s) it defines.
+- **Geometry Types** - geometry primitives
+- **Variables** - arrays of data
+- **Time series** - individual samples of a larger series
+- **Tree Table** - hierarchical data structure, use to convey dense record type data
+- **Image Stream** - Binary format image data
 
 ## Source
 
-A source of XVIZ streams. A source can be a pre-generated log loaded from a URL or a file, but it can also be a live data served over e.g. a socket.
+A source of XVIZ streams. A source can be a pre-generated log loaded from a URL or a file, but it
+can also be a live data served over e.g. a socket.
 
 Each source contains one or more streams, as well as a metadata about the streams.
-
 
 ## Metadata
 
 A special XVIZ message that contains descriptive information about the data source and its streams.
 
-
 ## Primitive
 
-An XVIZ primitive is a geometric object such as a point, line, polygon etc that should be visualized. It can be tagged and given special styling (color etc).
-
+An XVIZ primitive is a geometric object such as a point, line, polygon etc that should be
+visualized. It can be tagged and given special styling (color etc).
 
 ## Style
 
-XVIZ support a form of stylesheets, allowing object properties to be specified based stream and class.
-
+XVIZ support a form of stylesheets, allowing object properties to be specified based stream and
+class.
 
 ## Object
 
-Objects can be defined by attaching identifiers to primitives, variables, and time series. The identifier enables linking information across streams and time slices.
-
+Objects can be defined by attaching identifiers to primitives, variables, and time series. The
+identifier enables linking information across streams and time slices.
 
 ## Variable
 
-A sequences of values the occur at a one time.  Like the speed of travel over a planned path for a vehicle.  Each time time you get an update to a variable stream, the full list of values changes.
-
+A sequences of values the occur at a one time. Like the speed of travel over a planned path for a
+vehicle. Each time time you get an update to a variable stream, the full list of values changes.
 
 ## Time Series
 
-Time stamped values can be included in streams.  Each time the stream updates you get a new timestamp, value pair.
-
+Time stamped values can be included in streams. Each time the stream updates you get a new
+timestamp, value pair.
 
 ## Video
 
 XVIZ can sync with external video sources provided that they have been encoded in a suitable way.
 
-
 ## Encoding
 
-The XVIZ protocol specification does not prescribe any given encoding, however the XVIZ libraries come with support for encoding and parsing in JSON.
+The XVIZ protocol specification does not prescribe any given encoding, however the XVIZ libraries
+come with support for encoding and parsing in JSON.

--- a/docs/overview/conventions.md
+++ b/docs/overview/conventions.md
@@ -4,7 +4,6 @@
 
 Streams are named in accordance with a few simple rules.
 
-
 ### Use file system-like hierarchical names
 
 **Must** - uses path separators
@@ -26,7 +25,6 @@ All of the objects go on the same stream, using the `id` field to tell them apar
 This ignores the 'id' support of elements in XVIZ and provides no cross stream object linking.
 
 `/object/123`
-
 
 ## Stream Structure
 

--- a/docs/overview/related.md
+++ b/docs/overview/related.md
@@ -1,10 +1,12 @@
 # Related Projects
 
-* [rviz](https://github.com/ros-visualization/rviz) - ROS 3D Robot Visualizer
-* [rosbag](https://www.npmjs.com/package/rosbag) - ROSBAG reading support for Javascript
-* [glTF 2.0](https://github.com/KhronosGroup/glTF) - "JPEG for 3D", standard for 3D scene interchange, optimized for fast loading and the Web, has wide import & export support.
-* [USD/USDZ](https://graphics.pixar.com/usd/docs/index.html) - portable format for storing arbitrary 3D scenes, animations and scene graphs, in production pipelines, used and developed by Pixar.
-* [x3dom](https://www.x3dom.org/) - declarative 3D content format, built in WebGL support.
-* [A-Frame](https://aframe.io/) - declarative DOM style system for 3D VR applications.
-* [VRML 2.0](http://gun.teipir.gr/VRML-amgem/spec/index.html) - 1990’s format for full 3D scene description, in the spirit of a 3D HTML.
-
+- [rviz](https://github.com/ros-visualization/rviz) - ROS 3D Robot Visualizer
+- [rosbag](https://www.npmjs.com/package/rosbag) - ROSBAG reading support for Javascript
+- [glTF 2.0](https://github.com/KhronosGroup/glTF) - "JPEG for 3D", standard for 3D scene
+  interchange, optimized for fast loading and the Web, has wide import & export support.
+- [USD/USDZ](https://graphics.pixar.com/usd/docs/index.html) - portable format for storing arbitrary
+  3D scenes, animations and scene graphs, in production pipelines, used and developed by Pixar.
+- [x3dom](https://www.x3dom.org/) - declarative 3D content format, built in WebGL support.
+- [A-Frame](https://aframe.io/) - declarative DOM style system for 3D VR applications.
+- [VRML 2.0](http://gun.teipir.gr/VRML-amgem/spec/index.html) - 1990’s format for full 3D scene
+  description, in the spirit of a 3D HTML.

--- a/docs/overview/roadmap.md
+++ b/docs/overview/roadmap.md
@@ -1,30 +1,37 @@
 # Roadmap
 
-
 ## XVIZ Protocol Evolution
 
 Actively being discussed, some ideas are:
 
-* **Better support for binary data** - e.g. encoding graphical primitives in a GPU friendly way so that they can visualized more efficiently on the front-end.
+- **Better support for binary data** - e.g. encoding graphical primitives in a GPU friendly way so
+  that they can visualized more efficiently on the front-end.
 
-* **Improved support for static data** - Make it easier to load local maps and other contextual data.
-
+- **Improved support for static data** - Make it easier to load local maps and other contextual
+  data.
 
 ## XVIZ Library Improvements
 
-* **Builder Support for C++ and other Languages** - We want to provide support for generating XVIZ from non-JavaScript backends, such as C++, Python etc. We currently envision one or more versions of the XVIZ builder APIs to be ported to other languages.
+- **Builder Support for C++ and other Languages** - We want to provide support for generating XVIZ
+  from non-JavaScript backends, such as C++, Python etc. We currently envision one or more versions
+  of the XVIZ builder APIs to be ported to other languages.
 
-Note that for parsing we are currently focusing on visualizing XVIZ in the browser (i.e. in JavaScript. We'd be interested in collaborating in case someone wants to implement parsing of XVIZ in other languages such as C++).
+Note that for parsing we are currently focusing on visualizing XVIZ in the browser (i.e. in
+JavaScript. We'd be interested in collaborating in case someone wants to implement parsing of XVIZ
+in other languages such as C++).
 
-
-* **Support for streaming XVIZ** - Ideally we want to provide a non-JavaScript based socket server to serve as a reference/starting point.
-
+- **Support for streaming XVIZ** - Ideally we want to provide a non-JavaScript based socket server
+  to serve as a reference/starting point.
 
 ## Ecosystem Aspirations
 
-* **UI Applications** - We expect to keep improving [streetscape.gl](https://github.com/uber/streetscape.gl) as a reference application for XVIZ, and provide to support the ecosystem in case other open source applications emerge.
+- **UI Applications** - We expect to keep improving
+  [streetscape.gl](https://github.com/uber/streetscape.gl) as a reference application for XVIZ, and
+  provide to support the ecosystem in case other open source applications emerge.
 
+* **Base Converters from other formats** - To help new users quickly get started. (E.g. improved
+  rosbag support.)
 
-* **Base Converters from other formats** - To help new users quickly get started. (E.g. improved rosbag support.)
-
-* **Loaders for Open Map Libraries** - We want to work with providers of open autonomy-type map data and make sure turn-key loaders are available for those data sets to serve as the backdrop for XVIZ sequences
+* **Loaders for Open Map Libraries** - We want to work with providers of open autonomy-type map data
+  and make sure turn-key loaders are available for those data sets to serve as the backdrop for XVIZ
+  sequences

--- a/docs/overview/versioning.md
+++ b/docs/overview/versioning.md
@@ -1,17 +1,21 @@
 # Versioning and Support
 
-The XVIZ protocol is versioned as closely as possible in accordance with [Semantic Versioning](http://www.semver.org):
+The XVIZ protocol is versioned as closely as possible in accordance with
+[Semantic Versioning](http://www.semver.org):
 
-* Major versions will be released whenever there is a breaking API change.
-* Minor versions will be released whenever a change includes additions to the API, such as additional primitives, or additional fields for existing primitives.
-* Patch versions will be released whenever a change is released that in no way changes the API.
-
+- Major versions will be released whenever there is a breaking API change.
+- Minor versions will be released whenever a change includes additions to the API, such as
+  additional primitives, or additional fields for existing primitives.
+- Patch versions will be released whenever a change is released that in no way changes the API.
 
 ### Version Support Guarantees
 
-During H1 2018, major versions will be released no more often than every two months. From H2 2018 onward, major versions will be released no more often than every 6 months. Minor and patch updates may be released at any time.
+During H1 2018, major versions will be released no more often than every two months. From H2 2018
+onward, major versions will be released no more often than every 6 months. Minor and patch updates
+may be released at any time.
 
-Support will be focused on on the most recent revisions in the current and previous major revisions. That is to say, given the revisions:
+Support will be focused on on the most recent revisions in the current and previous major revisions.
+That is to say, given the revisions:
 
 ```
 v2.0.0
@@ -24,7 +28,8 @@ V3.0.1
 
 Support will focus on `v3.0.1` and when required `v2.2.1`.
 
-
 ### Backwards Propagation of Updates
 
-Protocol improvements made in later versions of XVIZ will be back propagated to the previous supported version. For example, if a performance enhancement is made to a draw method in XVIZ v3, it will be similarly made in the lastest XVIZ v2.
+Protocol improvements made in later versions of XVIZ will be back propagated to the previous
+supported version. For example, if a performance enhancement is made to a draw method in XVIZ v3, it
+will be similarly made in the lastest XVIZ v2.

--- a/docs/protocol-formats/binary-protocol.md
+++ b/docs/protocol-formats/binary-protocol.md
@@ -1,30 +1,43 @@
 # XVIZ Binary Container Protocol Format
 
-XVIZ comes with parsing support for a binary container format. In this format, each message is packaged in a binary container or "envelope", that contains two "chunks":
-* a JSON chunk containing the JSON encoding of semantic parts of the data
-* a BIN chunk containing compact, back-to-back binary representations of large numeric arrays, images etc.
+XVIZ comes with parsing support for a binary container format. In this format, each message is
+packaged in a binary container or "envelope", that contains two "chunks":
 
-An intended benefit of the binary format is that large segments of data can be sent and processed natively.
+- a JSON chunk containing the JSON encoding of semantic parts of the data
+- a BIN chunk containing compact, back-to-back binary representations of large numeric arrays,
+  images etc.
 
+An intended benefit of the binary format is that large segments of data can be sent and processed
+natively.
 
 # Parsing Support
 
-XVIZ parsing functions will decode the binary container, parse the JSON and resolve binary references. The application will get a "patched" JSON structure, with the difference from the basic JSON protocol format being that certain arrays will be compact typed arrays instead of classic JavaScript arrays.
+XVIZ parsing functions will decode the binary container, parse the JSON and resolve binary
+references. The application will get a "patched" JSON structure, with the difference from the basic
+JSON protocol format being that certain arrays will be compact typed arrays instead of classic
+JavaScript arrays.
 
-Typed arrays do not support nesting so all numbers will be laid out flat and the application needs to know how many values represent one element, for instance 3 values represent the `x, y, z` coordinates of a point.
-
+Typed arrays do not support nesting so all numbers will be laid out flat and the application needs
+to know how many values represent one element, for instance 3 values represent the `x, y, z`
+coordinates of a point.
 
 ## Details on Binary Container Format
 
-The container format is an implementation of the GLB binary container format defined in the glTF specification. However the `accessor`/`bufferView` tables specified by `glTF` are quite verbose for the many small buffers used by XVIZ, and accordingly XVIZ may use custom tables for more compact messages.
+The container format is an implementation of the GLB binary container format defined in the glTF
+specification. However the `accessor`/`bufferView` tables specified by `glTF` are quite verbose for
+the many small buffers used by XVIZ, and accordingly XVIZ may use custom tables for more compact
+messages.
 
 References:
-* [glTF 2 Poster](https://raw.githubusercontent.com/KhronosGroup/glTF/master/specification/2.0/figures/gltfOverview-2.0.0a.png)
-* [glTF 2 Spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0)
 
+- [glTF 2 Poster](https://raw.githubusercontent.com/KhronosGroup/glTF/master/specification/2.0/figures/gltfOverview-2.0.0a.png)
+- [glTF 2 Spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0)
 
 ## Remarks
 
 Note on endianness:
-* glTF is little endian: GLB header is little endian. glTF Buffer contents are specified to be little endian.
-* Essentially all of the current web is little endian, so potential big-endian issues are igored for now.
+
+- glTF is little endian: GLB header is little endian. glTF Buffer contents are specified to be
+  little endian.
+- Essentially all of the current web is little endian, so potential big-endian issues are igored for
+  now.

--- a/docs/protocol-formats/json-protocol.md
+++ b/docs/protocol-formats/json-protocol.md
@@ -1,37 +1,38 @@
 # XVIZ JSON Protocol Format
 
-The JSON XVIZ format is a straight forward mapping of the XVIZ protocol schema contained within an envelope that denotes what type the object is.
-
+The JSON XVIZ format is a straight forward mapping of the XVIZ protocol schema contained within an
+envelope that denotes what type the object is.
 
 ## Data Type Conversion
 
-The table below provides guidelines on how to convert the types specified in this document into JSON.
+The table below provides guidelines on how to convert the types specified in this document into
+JSON.
 
-| Type  | JSON Representation |
-| ---   |---                  |
-| All Core Types (primitive, annotation, styles) | Object `{}` |
-| `list<>` | Array [] |
-| `map<>` | Object `{"key": "value"}` |
-| `optional<T>` | `null` if not present, otherwise T |
-
+| Type                                           | JSON Representation                |
+| ---------------------------------------------- | ---------------------------------- |
+| All Core Types (primitive, annotation, styles) | Object `{}`                        |
+| `list<>`                                       | Array []                           |
+| `map<>`                                        | Object `{"key": "value"}`          |
+| `optional<T>`                                  | `null` if not present, otherwise T |
 
 ## Data Envelope
 
 All XVIZ messages are enveloped with additional metadata about how to interpret them.
 
 The possible message types are captured in the message_types enum. Supported types are:
-* `session_start` - Sent from the client upon connection
-* `session_reconfigure` - Sent from the client upon reconfiguration
-* `session_metadata` - Sent from the server upon connection or reconfiguration
-* `state_update` - Sent for messages containing primitives and variables
 
-| Name                        | Type               | Description |
-| ---                         | ---                | --- |
-| `type` | `message_type` |  Explicit type of this message |
-| `data` | `message` | The actual message itself |
+- `session_start` - Sent from the client upon connection
+- `session_reconfigure` - Sent from the client upon reconfiguration
+- `session_metadata` - Sent from the server upon connection or reconfiguration
+- `state_update` - Sent for messages containing primitives and variables
 
+| Name   | Type           | Description                   |
+| ------ | -------------- | ----------------------------- |
+| `type` | `message_type` | Explicit type of this message |
+| `data` | `message`      | The actual message itself     |
 
 A JSON example of this envelope for a state update message is
+
 ```
 {
     "type": "state_update",

--- a/docs/protocol-schema/core-protocol.md
+++ b/docs/protocol-schema/core-protocol.md
@@ -2,8 +2,9 @@
 
 ## Introduction
 
-XVIZ is an abstract visual world state description format that can be updated both incrementally and with complete snapshots.  It is designed to separate the reduction of large complex data streams into a logical visual hierarchy from the building of rich applications to view that data.
-
+XVIZ is an abstract visual world state description format that can be updated both incrementally and
+with complete snapshots. It is designed to separate the reduction of large complex data streams into
+a logical visual hierarchy from the building of rich applications to view that data.
 
 ## Data Model
 
@@ -11,110 +12,127 @@ Here is a map of all the objects in a typical XVIZ world state:
 
 ### Streams and World State
 
-XVIZ divides the state of the world into a set of streams.  This allows user to quickly explore and filter the visual world to suit their use case.  Each stream changes over time atomically.  The world state represents a complete set of all the latest stream states for a particular time.
+XVIZ divides the state of the world into a set of streams. This allows user to quickly explore and
+filter the visual world to suit their use case. Each stream changes over time atomically. The world
+state represents a complete set of all the latest stream states for a particular time.
 
 ### Primitives and Objects
 
 The base types of XVIZ are individual elements of data: primitives, variables and time series.
 
-* **Primitives** are abstract geometries.
-* **Variables** are arrays of data (often over time).
-* **Time series** are individual samples of a larger series.
+- **Primitives** are abstract geometries.
+- **Variables** are arrays of data (often over time).
+- **Time series** are individual samples of a larger series.
 
-These individual elements have a common semantics meaning, which is captured by the collection they are contained within, the stream.
+These individual elements have a common semantics meaning, which is captured by the collection they
+are contained within, the stream.
 
-As an example, the stream `/object/shape` would contain all primitive shapes, while /object/velocity would contain the numeric value for the objects' velocities.
+As an example, the stream `/object/shape` would contain all primitive shapes, while /object/velocity
+would contain the numeric value for the objects' velocities.
 
-Since the representation for an object is split across streams, XVIZ base types can have an ID which will be used to maintain the relationship of the data. In the example above, the /shape stream would transmit the object’s shape information, while the /velocity stream would transmit the object’s velocity information. These streams are separated for ease of parsing and improved data compression - for example, object shapes may only need to be updated once per second, whereas velocities might be more useful updated 10 times per second.
-
-
+Since the representation for an object is split across streams, XVIZ base types can have an ID which
+will be used to maintain the relationship of the data. In the example above, the /shape stream would
+transmit the object’s shape information, while the /velocity stream would transmit the object’s
+velocity information. These streams are separated for ease of parsing and improved data
+compression - for example, object shapes may only need to be updated once per second, whereas
+velocities might be more useful updated 10 times per second.
 
 ### Poses
 
-A core part of XVIZ is knowing the location of the vehicle(s) so they can be displayed relative to the other data. This defines the location of the vehicle from it's own arbitrary frame, along with it's location in latitude, longitude, form.
+A core part of XVIZ is knowing the location of the vehicle(s) so they can be displayed relative to
+the other data. This defines the location of the vehicle from it's own arbitrary frame, along with
+it's location in latitude, longitude, form.
 
-| Name           | Type               | Description |
-| ---            | ---                | --- |
-| `timestamp`    | `float`            | The vehicle/log transmission\_time associated with this data. |
-| `mapOrigin`    | `map_origin`       | Uniquely identifies an object for all time. |
-| `position`     | `array<float>(3)`  | x, y, z position in meters |
-| `orientation`  | `array<float>(3)`  | roll, pitch, yaw angle in radians  |
+| Name          | Type              | Description                                                  |
+| ------------- | ----------------- | ------------------------------------------------------------ |
+| `timestamp`   | `float`           | The vehicle/log transmission_time associated with this data. |
+| `mapOrigin`   | `map_origin`      | Uniquely identifies an object for all time.                  |
+| `position`    | `array<float>(3)` | x, y, z position in meters                                   |
+| `orientation` | `array<float>(3)` | roll, pitch, yaw angle in radians                            |
 
 The `map_origin` object describes a location in geographic coordinates and altitude:
 
-| Name        | Type     | Description |
-| ---         | ---      | --- |
-| `longitude` | `float`  | The east-west geographic coordinate in degrees |
-| `latitude`  | `float`  | The north-south geographic coordinate in degrees |
-| `altitude`  | `float`  | The altitude above sea level in meters |
-
+| Name        | Type    | Description                                      |
+| ----------- | ------- | ------------------------------------------------ |
+| `longitude` | `float` | The east-west geographic coordinate in degrees   |
+| `latitude`  | `float` | The north-south geographic coordinate in degrees |
+| `altitude`  | `float` | The altitude above sea level in meters           |
 
 ### Styles
 
-Similar to CSS each primitive can have one or more classes, each of which can have associated style information.  This allows the styling information to be sent out of band with the main data flows, and only once.  Learn more in the [style specification](/docs/protocol-schema/style-specification.md).
-
+Similar to CSS each primitive can have one or more classes, each of which can have associated style
+information. This allows the styling information to be sent out of band with the main data flows,
+and only once. Learn more in the
+[style specification](/docs/protocol-schema/style-specification.md).
 
 ### Annotations
 
-Annotations are themselves sent as XVIZ streams, but provide strictly supplemental information for another stream. Annotations are used when one team needs to append additional visual information to objects other than their own.
-
+Annotations are themselves sent as XVIZ streams, but provide strictly supplemental information for
+another stream. Annotations are used when one team needs to append additional visual information to
+objects other than their own.
 
 ## Implementations
 
-XVIZ is used when talking to a server or reading data exported and stored on disk. To learn more about them see:
- - [Session Protocol](/docs/protocol-schema/session-protocol.md)
- - ETL - current unspecified
+XVIZ is used when talking to a server or reading data exported and stored on disk. To learn more
+about them see:
+
+- [Session Protocol](/docs/protocol-schema/session-protocol.md)
+- ETL - current unspecified
 
 > Need XVIZ OSS specification for XVIZ 2.0 ETL format
 
-Both of those methods can use either of the two public XVIZ protocol implementations to encode the types described below:
+Both of those methods can use either of the two public XVIZ protocol implementations to encode the
+types described below:
 
- - [JSON protocol](/docs/protocol-formats/json-protocol.md) - a straight forward mapping of above types into JSON
- - [Binary protocol](/docs/protocol-formats/binary-protocol.md) - a Hybrid JSON binary protocol designed for larger data sets and faster performance
-
+- [JSON protocol](/docs/protocol-formats/json-protocol.md) - a straight forward mapping of above
+  types into JSON
+- [Binary protocol](/docs/protocol-formats/binary-protocol.md) - a Hybrid JSON binary protocol
+  designed for larger data sets and faster performance
 
 ## ID Types
 
-These are XVIZ specific ID types used throughout multiple different parts of the protocol.  They are listed here so that they can be defined only once.
+These are XVIZ specific ID types used throughout multiple different parts of the protocol. They are
+listed here so that they can be defined only once.
 
-| ID Type               | Type            | Description |
-| ---                   | ---             | --- |
-| `stream_id`           | `string`        | Describes a part of the world we are visualizing, example "/object/polygon" |
-| `object_id`           | `guid`          | Uniquely identifies an object for all time. |
-| `class_id`            | `string`        | Used to denote which styles apply to an object. |
-| `widget_id`           | `guid`          | Uniquely identifies a UI element. |
-| `treetable_column_id` | `uint32`        | Used to associate treetable node values with their appropriate columns. Notably not a GUID to  save space. |
-| `treetable_node_id`   | `uint32`        | Uniquely identifies a node in a tree table and acts as a pointer to the node |
-| `type_id`             | `variable_type` | An enum of bool, integer, double, and string types |
-
+| ID Type               | Type            | Description                                                                                               |
+| --------------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
+| `stream_id`           | `string`        | Describes a part of the world we are visualizing, example "/object/polygon"                               |
+| `object_id`           | `guid`          | Uniquely identifies an object for all time.                                                               |
+| `class_id`            | `string`        | Used to denote which styles apply to an object.                                                           |
+| `widget_id`           | `guid`          | Uniquely identifies a UI element.                                                                         |
+| `treetable_column_id` | `uint32`        | Used to associate treetable node values with their appropriate columns. Notably not a GUID to save space. |
+| `treetable_node_id`   | `uint32`        | Uniquely identifies a node in a tree table and acts as a pointer to the node                              |
+| `type_id`             | `variable_type` | An enum of bool, integer, double, and string types                                                        |
 
 ## Style
 
-Style information describes the appearance of primitives. Color information can be directly attached to primitives but styles pertaining to many or all primitives should be pulled out into style messages. This reduces the amount of data sent across the network and improves maintainability.
+Style information describes the appearance of primitives. Color information can be directly attached
+to primitives but styles pertaining to many or all primitives should be pulled out into style
+messages. This reduces the amount of data sent across the network and improves maintainability.
 
 Details in separate [style specification](/docs/protocol-schema/style-specification.md).
 
-| Name         | Type                              | Description |
-| ---          | ---                               | --- |
-| `fields`     | `map<style_field, value_variant>` | The variant for HIDL will be a custom type.
+| Name     | Type                              | Description                                 |
+| -------- | --------------------------------- | ------------------------------------------- |
+| `fields` | `map<style_field, value_variant>` | The variant for HIDL will be a custom type. |
 
-**value_variant** - the most efficient variant type we can make represents, string, rgba_color, float, boolean
-
+**value_variant** - the most efficient variant type we can make represents, string, rgba_color,
+float, boolean
 
 ## Stream Set
 
-This is a single cohesive set of streams which all happened at the same time and be associated with a single system frame.  This is what an XVIZ extractor produces.
+This is a single cohesive set of streams which all happened at the same time and be associated with
+a single system frame. This is what an XVIZ extractor produces.
 
-| Name            | Type                                | Description |
-| ---             | ---                                 | --- |
-| `timestamp`     | `timestamp`                         | The vehicle/log transmission\_time associated with this data. |
-| `primitives`    | `map<stream_id, primitive_state>`   | Streams containing list of primitives.  |
-| `poses`         | `list<pose>`                        | Related vehicle poses  |
-| `time_series`   | `list<time_series_state>`           |   |
-| `future_states` | `map<stream_id, future_instances>`  | Streams containing This represents a collection of primitives at different timestamps, for the current stream set timestamp  |
-| `variables`     | `map<stream_id, variable_state>`    | Streams containing list of values.  |
-| `annotations`   | `map<stream_id, annotation_state>`  | Streams containing annotations  |
-
+| Name            | Type                               | Description                                                                                                                 |
+| --------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `timestamp`     | `timestamp`                        | The vehicle/log transmission_time associated with this data.                                                                |
+| `primitives`    | `map<stream_id, primitive_state>`  | Streams containing list of primitives.                                                                                      |
+| `poses`         | `list<pose>`                       | Related vehicle poses                                                                                                       |
+| `time_series`   | `list<time_series_state>`          |                                                                                                                             |
+| `future_states` | `map<stream_id, future_instances>` | Streams containing This represents a collection of primitives at different timestamps, for the current stream set timestamp |
+| `variables`     | `map<stream_id, variable_state>`   | Streams containing list of values.                                                                                          |
+| `annotations`   | `map<stream_id, annotation_state>` | Streams containing annotations                                                                                              |
 
 This is what a full stream set would look like populated with a basic example of each element:
 
@@ -138,14 +156,15 @@ This is what a full stream set would look like populated with a basic example of
 }
 ```
 
-
 ## Future Instances
 
-Future instances are used to provide lookahead world states for a given instant. These future instances can be used to keep track of what is predicted to happen in the seconds after a given instant. These are not for normal time ordered primitives.
+Future instances are used to provide lookahead world states for a given instant. These future
+instances can be used to keep track of what is predicted to happen in the seconds after a given
+instant. These are not for normal time ordered primitives.
 
-| Name         | Type                    | Description |
-| ---          | ---                     | --- |
-| `timestamps` | `list<timestamp>`       | A list of timestamps in the future |
+| Name         | Type                    | Description                             |
+| ------------ | ----------------------- | --------------------------------------- |
+| `timestamps` | `list<timestamp>`       | A list of timestamps in the future      |
 | `primitives` | `list<list<primitive>>` | A list of primitives for each timestamp |
 
 ```js
@@ -171,13 +190,12 @@ Future instances are used to provide lookahead world states for a given instant.
 }
 ```
 
-
 ## Primitive State
 
 /object/bounds -> [<polygon>, <polygon>]
 
-| Name         | Type              | Description |
-| ---          | ---               | --- |
+| Name         | Type              | Description        |
+| ------------ | ----------------- | ------------------ |
 | `primitives` | `list<primitive>` | Primitives to draw |
 
 ```js
@@ -188,17 +206,16 @@ Future instances are used to provide lookahead world states for a given instant.
         }
     ]
 }
-
 ```
-
 
 ## Variable State
 
-Maps a stream like `/constraints` to a single or multiple item list of variables.  Multiple items indicate each object refers to a different variable.
+Maps a stream like `/constraints` to a single or multiple item list of variables. Multiple items
+indicate each object refers to a different variable.
 
-| Name         | Type              | Description |
-| ---          | ---               | --- |
-| `variables`  | `list<variables>` | Variables to display |
+| Name        | Type              | Description          |
+| ----------- | ----------------- | -------------------- |
+| `variables` | `list<variables>` | Variables to display |
 
 ```js
 {
@@ -210,16 +227,17 @@ Maps a stream like `/constraints` to a single or multiple item list of variables
 }
 ```
 
-
 ## Time Series State
 
-This models a set of values that changes each time a data is transformed. These are used to provide instantaneous data for a moment in time. These are not used for representing the values of functions in the future. For that you would want to use Variable States.
+This models a set of values that changes each time a data is transformed. These are used to provide
+instantaneous data for a moment in time. These are not used for representing the values of functions
+in the future. For that you would want to use Variable States.
 
-| Name        | Type                       | Description |
-| ---         | ---                        | --- |
-| `timestamp` | `timestamp`                | The vehicle/log transmission\_time associated with this data. |
-| `values`    | `list<{stream_id, value}>` | Number/string/whatever |
-| `object_id` | `optional<object_id>`      | Associated object, optional |
+| Name        | Type                       | Description                                                  |
+| ----------- | -------------------------- | ------------------------------------------------------------ |
+| `timestamp` | `timestamp`                | The vehicle/log transmission_time associated with this data. |
+| `values`    | `list<{stream_id, value}>` | Number/string/whatever                                       |
+| `object_id` | `optional<object_id>`      | Associated object, optional                                  |
 
 Here is an example `time_series_state` for a system producing multiple values at a specific time:
 
@@ -233,31 +251,32 @@ Here is an example `time_series_state` for a system producing multiple values at
 }
 ```
 
-
 ## Point3D
 
-The Point3D type is used to represent coordinates. Note that it does not use fields x, y, and z but rather has an array of three floating point values with the indexes 0, 1, and 2 corresponding to x, y, and z respectively.
+The Point3D type is used to represent coordinates. Note that it does not use fields x, y, and z but
+rather has an array of three floating point values with the indexes 0, 1, and 2 corresponding to x,
+y, and z respectively.
 
-| Name          | Type              | Description |
-| ---           | ---               | --- |
+| Name          | Type              | Description                 |
+| ------------- | ----------------- | --------------------------- |
 | `coordinates` | `array<float>(3)` | What kind of object is this |
-
 
 ## Primitive
 
-Primitives are the most basic units of rendering data sent across the network.  Every primitives has all the following fields:
+Primitives are the most basic units of rendering data sent across the network. Every primitives has
+all the following fields:
 
-| Name      | Type                  | Description |
-| ---       | ---                   | --- |
-| `type`    | `primitive_type`      | What kind of object is this |
-| `style`   | `optional<style>`     | Optional inline style |
-| `classes` | `list<class_id>`      | Semantic/visualize classes. |
+| Name      | Type                  | Description                                    |
+| --------- | --------------------- | ---------------------------------------------- |
+| `type`    | `primitive_type`      | What kind of object is this                    |
+| `style`   | `optional<style>`     | Optional inline style                          |
+| `classes` | `list<class_id>`      | Semantic/visualize classes.                    |
 | `id`      | `optional<object_id>` | Which object is this primitive associated with |
 
 To see all the primitives see:
 
- - [Geometry Primitives](/docs/protocol-schema/geometry-primitives.md)
- - [Panel Primitives](/docs/protocol-schema/panel-specification.md)
+- [Geometry Primitives](/docs/protocol-schema/geometry-primitives.md)
+- [Panel Primitives](/docs/protocol-schema/panel-specification.md)
 
 As an example in JSON of a `point` primitive using style classes:
 
@@ -270,7 +289,8 @@ As an example in JSON of a `point` primitive using style classes:
 }
 ```
 
-You can do the same with inline styles but it is much less efficient to send the same styling information for each object over and over.  Here is what it looks like to use an inline style form:
+You can do the same with inline styles but it is much less efficient to send the same styling
+information for each object over and over. Here is what it looks like to use an inline style form:
 
 ```js
 {
@@ -290,26 +310,30 @@ You can do the same with inline styles but it is much less efficient to send the
 }
 ```
 
-
 ## Variables
 
-Variable are for representing metrics data as a function of time, distance, or anything else. Variable states can be used to provide lookahead values at a given moment, similar to how future instances provide visual lookahead information.
+Variable are for representing metrics data as a function of time, distance, or anything else.
+Variable states can be used to provide lookahead values at a given moment, similar to how future
+instances provide visual lookahead information.
 
-An example of this would be planning data as a function of time over the next 10 seconds. For example, the following three streams would represent three variable states
+An example of this would be planning data as a function of time over the next 10 seconds. For
+example, the following three streams would represent three variable states
 
     /plan/time
     /plan/velocity
     /plan/jerk
 
-Each stream would contain the same number of values and then the velocity and jerk streams could be plotted as a function of the time stream. For more details on how to plot see the UI Metadata section.
+Each stream would contain the same number of values and then the velocity and jerk streams could be
+plotted as a function of the time stream. For more details on how to plot see the UI Metadata
+section.
 
-| Name     | Type                      | Description |
-| ---      | ---                       | --- |
-| `values`    | `list<values>`         | The values |
-| `object_id` | `optional<object_id>`  | Associated object, optional |
+| Name        | Type                  | Description                 |
+| ----------- | --------------------- | --------------------------- |
+| `values`    | `list<values>`        | The values                  |
+| `object_id` | `optional<object_id>` | Associated object, optional |
 
-
-As an example a complete [`stream_set`](/docs/protocol-schema/core-protocol.md#stream-set), containing the above variables would look like:
+As an example a complete [`stream_set`](/docs/protocol-schema/core-protocol.md#stream-set),
+containing the above variables would look like:
 
 ```js
 {
@@ -317,25 +341,25 @@ As an example a complete [`stream_set`](/docs/protocol-schema/core-protocol.md#s
 }
 ```
 
-
-
 ## Annotations
 
-Annotations are additional data attached to existing primitive types. Annotations currently cover visual changes in the appears of existing object.
+Annotations are additional data attached to existing primitive types. Annotations currently cover
+visual changes in the appears of existing object.
 
 Annotations must be produced in the stream set for as long as that annotation is active.
 
 ### Base
 
-| Name     | Type              | Description |
-| ---      | ---               | --- |
-| `type`   | `annotation_type` | One of the possible annotation types,  what action to take when the annotation is triggered |
-| `object` | `object_id`       | The object the annotation corresponds to |
+| Name     | Type              | Description                                                                                |
+| -------- | ----------------- | ------------------------------------------------------------------------------------------ |
+| `type`   | `annotation_type` | One of the possible annotation types, what action to take when the annotation is triggered |
+| `object` | `object_id`       | The object the annotation corresponds to                                                   |
 
 ### Visual
+
 Visual annotations are change how things are rendered.
 
-| Name            | Type                     | Description |
-| ---             | ---                      | --- |
-| `style_classes` | `optional<list<string>>` | A list of style classes to apply |
+| Name            | Type                     | Description                                                     |
+| --------------- | ------------------------ | --------------------------------------------------------------- |
+| `style_classes` | `optional<list<string>>` | A list of style classes to apply                                |
 | `style_info`    | `optional<style>`        | A block of style information as outlined in the "Style" section |

--- a/docs/protocol-schema/geometry-primitives.md
+++ b/docs/protocol-schema/geometry-primitives.md
@@ -2,29 +2,32 @@
 
 The geometry primitives currently supported in XVIZ are:
 
-* `point`
-* `polygon`
-* `polyline`
-* `circle`
-* `stadium`
-* `text`
-* `image`
+- `point`
+- `polygon`
+- `polyline`
+- `circle`
+- `stadium`
+- `text`
+- `image`
 
 ## Flat Arrays
 
-For faster loading directly in memory buffers where you see `list<Point3d>` a flat list of numbers can be supplied.  In those cases that list must be a multiple of 3, where each 3 elements is the `(x,y,z)` tuple that makes up a 3D point.
+For faster loading directly in memory buffers where you see `list<Point3d>` a flat list of numbers
+can be supplied. In those cases that list must be a multiple of 3, where each 3 elements is the
+`(x,y,z)` tuple that makes up a 3D point.
 
-The same is true of `list<color>`, instead the list must be a multiple of 4, where each element is the `(r, g, b, a)` color tuple.
-
+The same is true of `list<color>`, instead the list must be a multiple of 4, where each element is
+the `(r, g, b, a)` color tuple.
 
 ## Point Primitive
 
-The point primitive is the most basic XVIZ drawable. It can represent either a single point or a point cloud. If there is more than one vertex in the vertices field then it is a point cloud.
+The point primitive is the most basic XVIZ drawable. It can represent either a single point or a
+point cloud. If there is more than one vertex in the vertices field then it is a point cloud.
 
-| Name    | Type                   | Description |
-| ---     | ---                    | ---         |
-| points  | list<Point3d>          | If more than one point is in the list then this is a point cloud, otherwise it is just a single point. (Optionally flattened) |
-| colors  | optional<list<color>>  | If present this provides a color for every point in the `points` list, and overrides any inline or class color styling.  |
+| Name   | Type                  | Description                                                                                                                   |
+| ------ | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| points | list<Point3d>         | If more than one point is in the list then this is a point cloud, otherwise it is just a single point. (Optionally flattened) |
+| colors | optional<list<color>> | If present this provides a color for every point in the `points` list, and overrides any inline or class color styling.       |
 
 Example:
 
@@ -35,13 +38,12 @@ Example:
 }
 ```
 
-
 ## Polygon Primitive
 
 The polygon primitive is used to draw any closed shape.
 
-| Name    | Type           | Description |
-| ---     | ---            | ---         |
+| Name     | Type          | Description                                                                         |
+| -------- | ------------- | ----------------------------------------------------------------------------------- |
 | vertices | list<Point3d> | The vertices of the polygon. Minimum of 3 vertices required. (Optionally flattened) |
 
 JSON example using style class for styling:
@@ -53,13 +55,12 @@ JSON example using style class for styling:
 }
 ```
 
-
 ## PolyLine Primitive
 
 The polyline primitive is used to draw any polygonal chain.
 
-| Name     | Type          | Description |
-| ---      | ---           | ---         |
+| Name     | Type          | Description                                                                          |
+| -------- | ------------- | ------------------------------------------------------------------------------------ |
 | vertices | list<Point3d> | The vertices of the polyline. Minimum of 2 vertices required. (Optionally flattened) |
 
 JSON example using style class for styling:
@@ -71,16 +72,14 @@ JSON example using style class for styling:
 }
 ```
 
-
 ## Circle Primitive
 
 The circle primitive is used to draw circles and rings, it’s center lines up with the object center.
 
-| Name    | Type           | Description |
-| ---     | ---            | ---         |
-| center  | point3d        | Continuous space position of the center of the circle |
-| radius_m | float32       | The radius of the circle in meters |
-
+| Name     | Type    | Description                                           |
+| -------- | ------- | ----------------------------------------------------- |
+| center   | point3d | Continuous space position of the center of the circle |
+| radius_m | float32 | The radius of the circle in meters                    |
 
 Example:
 
@@ -92,16 +91,16 @@ Example:
 }
 ```
 
-
 ## Stadium Primitive
 
-The stadium primitive is used to draw 2D geometric stadiums. As of XVIZ v2.0.0, stadiums are the closest that XVIZ has to support for 3D capsule shapes.
+The stadium primitive is used to draw 2D geometric stadiums. As of XVIZ v2.0.0, stadiums are the
+closest that XVIZ has to support for 3D capsule shapes.
 
-| Name     | Type           | Description |
-| ---      | ---            | ---         |
-| start    | point3d        | The midpoint of one end of the rectangle portion of a stadium that is adjacent to a semi-circle. |
-| end      | point3d        | The midpoint of the other end of the rectangle portion of the stadium which is adjacent to the other semi-circle. |
-| radius_m |float32         | The radius of the circles in meters |
+| Name     | Type    | Description                                                                                                       |
+| -------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| start    | point3d | The midpoint of one end of the rectangle portion of a stadium that is adjacent to a semi-circle.                  |
+| end      | point3d | The midpoint of the other end of the rectangle portion of the stadium which is adjacent to the other semi-circle. |
+| radius_m | float32 | The radius of the circles in meters                                                                               |
 
 Example:
 
@@ -114,16 +113,15 @@ Example:
 }
 ```
 
-
 ## Text Primitive
 
-The text primitive is used to render any kind of purely textual information.  Its position refers to the top left corner of the text.
+The text primitive is used to render any kind of purely textual information. Its position refers to
+the top left corner of the text.
 
-| Name     | Type           | Description |
-| ---      | ---            | ---         |
-| position | point3d        | Continuous space |
-| text     | string         | The actual text to display |
-
+| Name     | Type    | Description                |
+| -------- | ------- | -------------------------- |
+| position | point3d | Continuous space           |
+| text     | string  | The actual text to display |
 
 Example:
 
@@ -135,20 +133,19 @@ Example:
 }
 ```
 
-
 ## Image Primitive
 
 The image primitive is used to render existing graphics.
 
-| Name      | Type           | Description |
-| ---       | ---            | ---         |
-| position  | point3d        | The position of the top left corner of the image |
-| data      | byte_buffer    | Packed RGB camera image data |
-| width_px  | float32        | Width of the source image in pixels |
-| height_px | float32        | Height of the source image in pixels |
+| Name      | Type        | Description                                      |
+| --------- | ----------- | ------------------------------------------------ |
+| position  | point3d     | The position of the top left corner of the image |
+| data      | byte_buffer | Packed RGB camera image data                     |
+| width_px  | float32     | Width of the source image in pixels              |
+| height_px | float32     | Height of the source image in pixels             |
 
-
-This is a pure JSON example, for efficiency reasons you would normally use the binary protocol which stores the raw image directly instead of needing to base64 encode it.
+This is a pure JSON example, for efficiency reasons you would normally use the binary protocol which
+stores the raw image directly instead of needing to base64 encode it.
 
 ```
 {

--- a/docs/protocol-schema/panel-specification.md
+++ b/docs/protocol-schema/panel-specification.md
@@ -2,56 +2,63 @@
 
 ## TreeTable Primitive
 
-The TreeTable primitive represents data in a way similar to that of a file system explorer window. The data is hierarchical with common fields at each node and some fields being empty depending on where the node sits in the tree. Each node is typically rendered as one row in TreeTable with higher level nodes being collapsible.
+The TreeTable primitive represents data in a way similar to that of a file system explorer window.
+The data is hierarchical with common fields at each node and some fields being empty depending on
+where the node sits in the tree. Each node is typically rendered as one row in TreeTable with higher
+level nodes being collapsible.
 
-| Name      | Type                     | Description |
-| ---       | ---                      | --- |
-| `columns` | `list<treetable_column>` | Data specifying the columns of the table portion of a TreeTable. |
+| Name      | Type                     | Description                                                                                           |
+| --------- | ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `columns` | `list<treetable_column>` | Data specifying the columns of the table portion of a TreeTable.                                      |
 | `nodes`   | `list<treetable_node>`   | Data specifying the contents of the nodes which can be thought of as the data of the rows in a table. |
-
 
 ### TreeTable Columns
 
-TreeTable columns correspond to the fields available at each node in the TreeTable. Additionally, they contain information on the type of data represented in the column and the units of the data represented.
+TreeTable columns correspond to the fields available at each node in the TreeTable. Additionally,
+they contain information on the type of data represented in the column and the units of the data
+represented.
 
-| Name           | Type               | Description |
-| ---            | ---                | --- |
-| `display_text` | `string`           | The actual text to display in the header of the TreeTable |
-| `type`         | `type_id`          | One of the acceptable types for XVIZ variables |
+| Name           | Type               | Description                                                            |
+| -------------- | ------------------ | ---------------------------------------------------------------------- |
+| `display_text` | `string`           | The actual text to display in the header of the TreeTable              |
+| `type`         | `type_id`          | One of the acceptable types for XVIZ variables                         |
 | `unit`         | `optional<string>` | The unit for the data in this column like "meters" or "m/s" or "miles" |
-
 
 ### TreeTable Nodes (Rows)
 
-TreeTable nodes act like nodes in a tree or rows in a table. Note that columns are not guaranteed to have a value at every node. An example of this would be how many file browsers don’t list a size for folders.
+TreeTable nodes act like nodes in a tree or rows in a table. Note that columns are not guaranteed to
+have a value at every node. An example of this would be how many file browsers don’t list a size for
+folders.
 
-| Name            | Type                            | Description |
-| ---             | ---                             | --- |
-| `id`            | `treetable_node_id`             | The ID of this node within the TreeTable |
-| `parent`        | `treetable_node_id`             | The ID of the parent, essentially a pointer to parent |
+| Name            | Type                            | Description                                                     |
+| --------------- | ------------------------------- | --------------------------------------------------------------- |
+| `id`            | `treetable_node_id`             | The ID of this node within the TreeTable                        |
+| `parent`        | `treetable_node_id`             | The ID of the parent, essentially a pointer to parent           |
 | `column_values` | `list<optional<value_variant>>` | A list of the column values with index corresponding to column. |
-
 
 ### Error Handling in TreeTables
 
-When parsing TreeTable values into JSON representations there is a possibility that an unparsable value or a value with an incorrect data type is present. To prevent a single bad value from crashing the entire TreeTable conversion, these values will be represented as null and an error message will be included in a special errors field in the TreeTable’s JSON representation.
-
+When parsing TreeTable values into JSON representations there is a possibility that an unparsable
+value or a value with an incorrect data type is present. To prevent a single bad value from crashing
+the entire TreeTable conversion, these values will be represented as null and an error message will
+be included in a special errors field in the TreeTable’s JSON representation.
 
 #### The Errors Field
 
-The errors field is used to send additional information about any errors that came up while converting the TreeTable from its server side representation into JSON.
+The errors field is used to send additional information about any errors that came up while
+converting the TreeTable from its server side representation into JSON.
 
-| Name     | Type                    | Description |
-| ---      | ---                     | --- |
-| `errors` | `list<treetable_error>` |  A list of errors with more detailed information about what happened |
-
+| Name     | Type                    | Description                                                         |
+| -------- | ----------------------- | ------------------------------------------------------------------- |
+| `errors` | `list<treetable_error>` | A list of errors with more detailed information about what happened |
 
 #### The TreeTable Error Type
 
-The TreeTable error type includes information about the location within the treetable where the error occurred along with a description of what error has occurred.
+The TreeTable error type includes information about the location within the treetable where the
+error occurred along with a description of what error has occurred.
 
-| Name      | Type                  | Description |
-| ---       | ---                   | --- |
+| Name      | Type                  | Description                                |
+| --------- | --------------------- | ------------------------------------------ |
 | `message` | `string`              | Details of what error has occurred and why |
-| `column`  | `treetable_column_id` | The column with the error value |
-| `node`    | `treetable_node_id`   | The node/row with the error value |
+| `column`  | `treetable_column_id` | The column with the error value            |
+| `node`    | `treetable_node_id`   | The node/row with the error value          |

--- a/docs/protocol-schema/session-protocol.md
+++ b/docs/protocol-schema/session-protocol.md
@@ -1,57 +1,60 @@
 # Session Protocol Specification
 
-XVIZ can be used to visualize data from a running system.  In this contexts a client connects to a server and establishes a session.  At the start of the session the available streams and parameters are setup.
-
+XVIZ can be used to visualize data from a running system. In this contexts a client connects to a
+server and establishes a session. At the start of the session the available streams and parameters
+are setup.
 
 ## Session Message Types
 
 These describe client server communication to start and manage sessions.
 
-
 ### Session Start (from Client)
 
-Sent by the client to the service or encoded as URL parameters.  When the server gets this message it will start streaming data to the client as soon as it can.
+Sent by the client to the service or encoded as URL parameters. When the server gets this message it
+will start streaming data to the client as soon as it can.
 
 Common Parameters:
 
-| Name             | Type     | Description |
-| ---              | ---      | --- |
-| `version`        | `string` | Protocol version, for example `2.0.0` |
+| Name             | Type     | Description                                                   |
+| ---------------- | -------- | ------------------------------------------------------------- |
+| `version`        | `string` | Protocol version, for example `2.0.0`                         |
 | `profile`        | `string` | The backend configuration, defines what streams you will get. |
-| `session_type`   | `string` | Type of session being opened up. |
-| `message_format` | `string` | Format the data will be represented in. |
+| `session_type`   | `string` | Type of session being opened up.                              |
+| `message_format` | `string` | Format the data will be represented in.                       |
 
 **session_type** - valid values:
-* `live` - send data in real time
-* `log` - show data from a log
-* `unbuffered_log` - data is sent back in at the same rate it was logged
+
+- `live` - send data in real time
+- `log` - show data from a log
+- `unbuffered_log` - data is sent back in at the same rate it was logged
 
 **message_format** - valid values:
-* `json` - JSON types encoded as UT8 strings.
-* `binary` - Our GLB based binary container format.
 
+- `json` - JSON types encoded as UT8 strings.
+- `binary` - Our GLB based binary container format.
 
 ### Session Metadata (to Client)
 
 Sent to client upon connection
 
-| Name             | Type                              | Description |
-| ---              | ---                               | --- |
-| `version`        | `string`                          | Protocol version, for example `2.0.0` |
-| `streams`        | `map<stream_id, stream_metadata>` | Stream information |
-| `cameras`        | `map<string, camera_info>`        | Camera information indexed by camera name. |
-| `stream_aliases` | `map<stream_id, stream_id>`       | Map from an old to new stream names so the "schema" of streams can evolve without the client code being changed.  Even though this will be used infrequently having it in place allows seamless backend change without having to update the client.
-| `ui_config`      | `map<string, ui_panel_info>`      | Declarative UI panel configuration. |
+| Name             | Type                              | Description                                                                                                                                                                                                                                        |
+| ---------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`        | `string`                          | Protocol version, for example `2.0.0`                                                                                                                                                                                                              |
+| `streams`        | `map<stream_id, stream_metadata>` | Stream information                                                                                                                                                                                                                                 |
+| `cameras`        | `map<string, camera_info>`        | Camera information indexed by camera name.                                                                                                                                                                                                         |
+| `stream_aliases` | `map<stream_id, stream_id>`       | Map from an old to new stream names so the "schema" of streams can evolve without the client code being changed. Even though this will be used infrequently having it in place allows seamless backend change without having to update the client. |
+| `ui_config`      | `map<string, ui_panel_info>`      | Declarative UI panel configuration.                                                                                                                                                                                                                |
 
 #### Log Specific Metadata fields
 
-The following parameters are specific to log sessions and in metadata messages when a log session is created.
+The following parameters are specific to log sessions and in metadata messages when a log session is
+created.
 
-| Name             | Type               | Description |
-| ---              | ---                | --- |
-| `map_info`       | `map_metadata`     | Information about an applicable map, if any |
-| `log_info`       | `log_metadata`     | Information about the log |
-| `vehicle_info`   | `vehicle_metadata` | Vehicle type/platform info |
+| Name           | Type               | Description                                 |
+| -------------- | ------------------ | ------------------------------------------- |
+| `map_info`     | `map_metadata`     | Information about an applicable map, if any |
+| `log_info`     | `log_metadata`     | Information about the log                   |
+| `vehicle_info` | `vehicle_metadata` | Vehicle type/platform info                  |
 
 **map_info** - currently unspecified
 
@@ -59,19 +62,19 @@ The following parameters are specific to log sessions and in metadata messages w
 
 **vehicle_info** - currently unspecified
 
-
 ## Data Messages
 
 ### State Update
 
 This is a collection of stream sets for all extractor output.
 
-| Name             | Type                             | Description |
-| ---              | ---                              | --- |
-| `update_type`    | `enum { snapshot, incremental }` | Whether we have a complete or incremental update. |
-| `updates`        |  `list<stream_set>`              |            |
+| Name          | Type                             | Description                                       |
+| ------------- | -------------------------------- | ------------------------------------------------- |
+| `update_type` | `enum { snapshot, incremental }` | Whether we have a complete or incremental update. |
+| `updates`     | `list<stream_set>`               |                                                   |
 
-Here is a JSON example showing an incremental update that contains a single Stream Set, which itself has just the single `/object/polygon` containing a
+Here is a JSON example showing an incremental update that contains a single Stream Set, which itself
+has just the single `/object/polygon` containing a
 
 ```
 {
@@ -98,43 +101,42 @@ Here is a JSON example showing an incremental update that contains a single Stre
 
 ### Stream Metadata
 
-Metadata provides information about the structure of a stream. Ideally redundant information is removed from streams and put into metadata packets that are sent at the start of streaming or when a reconfiguration happens.
+Metadata provides information about the structure of a stream. Ideally redundant information is
+removed from streams and put into metadata packets that are sent at the start of streaming or when a
+reconfiguration happens.
 
-| Name          | Type                       | Description |
-| ---           | ---                        | --- |
-| `source`      | `string`                   | URL for where this stream comes from.  Allowing you to fetch the data from S3 for example.  An empty string means it comes through the standard XVIZ stream. |
-| `coordinate`  | `optional<enum{ frames }>` | Defaults to IDENTITY, defines the coordinate frame for the data in the stream |
-| `transform`   | `string, 4x4` | String for IDENTITY, 4x4 matrix for `VEHICLE_RELATIVE` |
-| `units`       | `string`                   | For variable and time series data this lets the user know what kind of data they are looking at. |
-| `value_map`   | `optional<enum{ stream values  }>` | A list of all of the values that will be sent on the stream. The indexes of the values are used to translate them into numeric values for plotting. |
-| `style_info`  | `map<class_id, style>`     | Describes how the data should be rendered. |
-
+| Name         | Type                              | Description                                                                                                                                                |
+| ------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`     | `string`                          | URL for where this stream comes from. Allowing you to fetch the data from S3 for example. An empty string means it comes through the standard XVIZ stream. |
+| `coordinate` | `optional<enum{ frames }>`        | Defaults to IDENTITY, defines the coordinate frame for the data in the stream                                                                              |
+| `transform`  | `string, 4x4`                     | String for IDENTITY, 4x4 matrix for `VEHICLE_RELATIVE`                                                                                                     |
+| `units`      | `string`                          | For variable and time series data this lets the user know what kind of data they are looking at.                                                           |
+| `value_map`  | `optional<enum{ stream values }>` | A list of all of the values that will be sent on the stream. The indexes of the values are used to translate them into numeric values for plotting.        |
+| `style_info` | `map<class_id, style>`            | Describes how the data should be rendered.                                                                                                                 |
 
 ### Camera Info
 
 Everything you need to display and deeply integrate video into a 3D application.
 
-| Name                        | Type               | Description |
-| ---                         | ---                | --- |
-| `human_name`                | `string`           | Readable camera name |
-| `source`                    | `string`           | either URL or "<internal>" (in XVIZ stream) |
-| `vehicle_position`          | `3x1 float vector` | Translation offset from vehicle position to camera position |
-| `vehicle_orientation`       | `3x3 float matrix` | Rotation offset from vehicle position to camera position |
-| `pixel_width`               | `int`              | Width of the raw camera images |
-| `pixel_height`              | `int`              | Height of the raw camera images |
-| `rectification_projection`  | `3x3 float matrix` | Transform raw pixel coordinates to rectified coordinates (use in a shader, reference).  Also called a "homography". |
-| `gl_projection`             | `4x4 float matrix` | Goes from 3D world coordinates to rectified image coordinates.  Use with OpenGL to draw 3D data on top of the image. |
-
-
+| Name                       | Type               | Description                                                                                                         |
+| -------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `human_name`               | `string`           | Readable camera name                                                                                                |
+| `source`                   | `string`           | either URL or "<internal>" (in XVIZ stream)                                                                         |
+| `vehicle_position`         | `3x1 float vector` | Translation offset from vehicle position to camera position                                                         |
+| `vehicle_orientation`      | `3x3 float matrix` | Rotation offset from vehicle position to camera position                                                            |
+| `pixel_width`              | `int`              | Width of the raw camera images                                                                                      |
+| `pixel_height`             | `int`              | Height of the raw camera images                                                                                     |
+| `rectification_projection` | `3x3 float matrix` | Transform raw pixel coordinates to rectified coordinates (use in a shader, reference). Also called a "homography".  |
+| `gl_projection`            | `4x4 float matrix` | Goes from 3D world coordinates to rectified image coordinates. Use with OpenGL to draw 3D data on top of the image. |
 
 ### UI Panel Info
 
 UI configuration that comes with the data explaining how best to display it.
 
-| Name             | Type              | Description |
-| ---              | ---               | --- |
-| `name`           | `string`          | Unique name for the panel |
+| Name             | Type              | Description                                     |
+| ---------------- | ----------------- | ----------------------------------------------- |
+| `name`           | `string`          | Unique name for the panel                       |
 | `needed_streams` | `list<stream_id>` | What streams are needed to populate this panel. |
-| `config`         | `declarative_ui`  | Declarative UI panel configuration |
+| `config`         | `declarative_ui`  | Declarative UI panel configuration              |
 
 **declarative_ui** - currently unspecified

--- a/docs/protocol-schema/style-specification.md
+++ b/docs/protocol-schema/style-specification.md
@@ -2,13 +2,14 @@
 
 # Introduction
 
-Styling in XVIZ happens at multiple levels.  This allows definition of defaults and control to avoid excessive style redundancy while not compromising on expressiveness.
+Styling in XVIZ happens at multiple levels. This allows definition of defaults and control to avoid
+excessive style redundancy while not compromising on expressiveness.
 
 The styling levels are, in resolution priority:
 
-* Object inline styles
-* Stream style classes
-* Stream style defaults
+- Object inline styles
+- Stream style classes
+- Stream style defaults
 
 # Style Levels
 
@@ -16,24 +17,30 @@ The styling levels are, in resolution priority:
 
 There are two ways to specify styles at the object level:
 
-* inline
-* classes
+- inline
+- classes
 
-Object styling happens thru the XVIZBuilder interface.  Specifially the `style()` and `classes()` functions.
+Object styling happens thru the XVIZBuilder interface. Specifially the `style()` and `classes()`
+functions.
 
 ## Style Classes
 
-Style classes work similar to HTML and CSS. Objects have class selectors defined, which resolve against a stylesheet.  XVIZ defines this stylesheet in the metadata (see XVIZMetadataBuilder) and the classes are scoped by streamId.
+Style classes work similar to HTML and CSS. Objects have class selectors defined, which resolve
+against a stylesheet. XVIZ defines this stylesheet in the metadata (see XVIZMetadataBuilder) and the
+classes are scoped by streamId.
 
-An important part of style class resolution is how style precedence is defined.  In XVIZ the last class takes precedences over classes that are defined before it.  This enables you to control your style ordering when defining classes using the XVIZMetadataBuilder.
+An important part of style class resolution is how style precedence is defined. In XVIZ the last
+class takes precedences over classes that are defined before it. This enables you to control your
+style ordering when defining classes using the XVIZMetadataBuilder.
 
 ### Selectors
 
-Each style object contains a `class` field that specifies the selector of the style. A style only applies to an object if the selector is matched.
+Each style object contains a `class` field that specifies the selector of the style. A style only
+applies to an object if the selector is matched.
 
-* `<name>` matches an object if it contains the given field.
-* Space separate multiple selectors to match an objects that satisfies them all.
-* If an object matches multiple selectors in a stylesheet, the one that is defined last trumps.
+- `<name>` matches an object if it contains the given field.
+- Space separate multiple selectors to match an objects that satisfies them all.
+- If an object matches multiple selectors in a stylesheet, the one that is defined last trumps.
 
 Here is an example of metadata with style classes defined for a stream '/object/shape'
 
@@ -64,7 +71,9 @@ Here is an example of metadata with style classes defined for a stream '/object/
 
 ## Stream Styling
 
-Stream styling allows you to define all the properties that an Object my use, but also includes additional properties that effectively act as toggles for rendering.  These properties allow for some performance advantage in the rendering pipeline when set to 'false'.
+Stream styling allows you to define all the properties that an Object my use, but also includes
+additional properties that effectively act as toggles for rendering. These properties allow for some
+performance advantage in the rendering pipeline when set to 'false'.
 
 Any style defined at the stream level will be the default style for any Objcts in that stream.
 
@@ -138,25 +147,29 @@ Cannot be customized per object - only effective when specified inside in the st
 
 ##### `radius_min_pixels` (number)
 
-The minimum pixels to draw the radius of `point` or `circle` primitives. Prevent the circles from being too small to see at a far-away zoom level.
+The minimum pixels to draw the radius of `point` or `circle` primitives. Prevent the circles from
+being too small to see at a far-away zoom level.
 
 Default: no constraint
 
 ##### `radius_max_pixels` (number)
 
-The maximum pixels to draw the radius of `point` or `circle` primitives. Prevent the circles from getting too large at a closed-up zoom level.
+The maximum pixels to draw the radius of `point` or `circle` primitives. Prevent the circles from
+getting too large at a closed-up zoom level.
 
 Default: no constraint
 
 ##### `stroke_width_min_pixels` (number)
 
-The minimum pixels to draw the stroke with of `line`, `path` or `polygon` primitives. Prevent the lines from being too thin to see at a far-away zoom level.
+The minimum pixels to draw the stroke with of `line`, `path` or `polygon` primitives. Prevent the
+lines from being too thin to see at a far-away zoom level.
 
 Default: no constraint
 
 ##### `stroke_width_max_pixels` (number)
 
-The maximum pixels to draw the stroke with of `line`, `path` or `polygon` primitives. Prevent the lines from getting too thick at a closed-up zoom level.
+The maximum pixels to draw the stroke with of `line`, `path` or `polygon` primitives. Prevent the
+lines from getting too thick at a closed-up zoom level.
 
 Default: no constraint
 
@@ -192,17 +205,24 @@ Default: `false`
 
 ## Explanation of Object Property and Stream Property
 
-Some styling features cause additional rendering overhead. For example, stroke and fill are done in separate passes.
+Some styling features cause additional rendering overhead. For example, stroke and fill are done in
+separate passes.
 
-In XVIZ we have setup styling to take advantage of this if possible.  For example, assume you have an extruded polygon stream. If you want to differentiate objects with stroke and fill style differences you can achieve this in 2 ways.
+In XVIZ we have setup styling to take advantage of this if possible. For example, assume you have an
+extruded polygon stream. If you want to differentiate objects with stroke and fill style differences
+you can achieve this in 2 ways.
 
 ### Use opacity to control stroke & fill on objects when enabled on the stream
 
-Since every object would have stroke and fill enabled you would need to set the color with an opacity 0 to have the stroke or fill not show up on a specific element. You will be paying the cost of these passes, but you will be able to have styling difference all within a single stream.
+Since every object would have stroke and fill enabled you would need to set the color with an
+opacity 0 to have the stroke or fill not show up on a specific element. You will be paying the cost
+of these passes, but you will be able to have styling difference all within a single stream.
 
 ### Separate out different styled object in different streams
 
-An alternative approach would be to seperate out objects in a different stream that had stream level settings for stroke and fill. This approach may reduce the overhead required in per-object styling and render costs.
+An alternative approach would be to seperate out objects in a different stream that had stream level
+settings for stroke and fill. This approach may reduce the overhead required in per-object styling
+and render costs.
 
 # Style Property Tables
 
@@ -211,49 +231,49 @@ An alternative approach would be to seperate out objects in a different stream t
 This table shows what style properties apply to each primitive type.
 
 | Type\Property | fill_color | radius | stroke_width | stroke_color | size | angle | text_anchor | alignment_baseline |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| circle | X | X | | | | | | |
-| image | | | | | | | | |
-| point | X | X | | | | | | |
-| polygon | X | | X | X | | | | |
-| polyline | | | X | X | | | | |
-| stadium | X | | X | X | | | | |
-| text | X | | | | X | X | X | X |
+| ------------- | ---------- | ------ | ------------ | ------------ | ---- | ----- | ----------- | ------------------ |
+| circle        | X          | X      |              |              |      |       |             |                    |
+| image         |            |        |              |              |      |       |             |                    |
+| point         | X          | X      |              |              |      |       |             |                    |
+| polygon       | X          |        | X            | X            |      |       |             |                    |
+| polyline      |            |        | X            | X            |      |       |             |                    |
+| stadium       | X          |        | X            | X            |      |       |             |                    |
+| text          | X          |        |              |              | X    | X     | X           | X                  |
 
 ## Stream Property Table
 
-This table shows the *additional* style properties that apply at the stream level for each primitive type.
+This table shows the _additional_ style properties that apply at the stream level for each primitive
+type.
 
-| Type\Property| opacity | stroked | filled | extruded | wireframe | radiusMinPixel | radius_max_pixels | stroke_width_min_pixels | stroke_width_min_pixels |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| circle |x| | | | |x|x| | |
-| image | | | | | | | | | |
-| point |x| | | | | | | | |
-| polygon |x|x|x|x|x| | |x|x|
-| polyline |x| | | | | | |x|x|
-| stadium |x|x|x|x|x| | |x|x|
-| text |x| | | | | | | | |
+| Type\Property | opacity | stroked | filled | extruded | wireframe | radiusMinPixel | radius_max_pixels | stroke_width_min_pixels | stroke_width_min_pixels |
+| ------------- | ------- | ------- | ------ | -------- | --------- | -------------- | ----------------- | ----------------------- | ----------------------- |
+| circle        | x       |         |        |          |           | x              | x                 |                         |                         |
+| image         |         |         |        |          |           |                |                   |                         |                         |
+| point         | x       |         |        |          |           |                |                   |                         |                         |
+| polygon       | x       | x       | x      | x        | x         |                |                   | x                       | x                       |
+| polyline      | x       |         |        |          |           |                |                   | x                       | x                       |
+| stadium       | x       | x       | x      | x        | x         |                |                   | x                       | x                       |
+| text          | x       |         |        |          |           |                |                   |                         |                         |
 
 ## Stype Property Default Values
 
-| Property | Default Value |
-| --- | --- |
-| fill_color | '#FFFFFF' |
-| stroke_color | '#FFFFFF' |
-| stroke_width | 1 |
-| radius | 1 |
-| height | 0 |
-| size | 12 |
-| angle | 0 |
-| text_anchor | 'middle' |
-| alignment_baseline | 'center' |
-| opacity | 1 |
-| stroked | true |
-| filled | true |
-| extruded | false |
-| wireframe | false |
-| radius_min_pixels| no constraint |
-| radius_max_pixels| no constraint |
+| Property                | Default Value |
+| ----------------------- | ------------- |
+| fill_color              | '#FFFFFF'     |
+| stroke_color            | '#FFFFFF'     |
+| stroke_width            | 1             |
+| radius                  | 1             |
+| height                  | 0             |
+| size                    | 12            |
+| angle                   | 0             |
+| text_anchor             | 'middle'      |
+| alignment_baseline      | 'center'      |
+| opacity                 | 1             |
+| stroked                 | true          |
+| filled                  | true          |
+| extruded                | false         |
+| wireframe               | false         |
+| radius_min_pixels       | no constraint |
+| radius_max_pixels       | no constraint |
 | stroke_width_min_pixels | no constraint |
 | stroke_width_max_pixels | no constraint |
-

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -27,7 +27,11 @@ case $MODE in
 
   *)
     echo "Checking prettier code styles..."
-    npx prettier-check "{modules,test}/**/*.js" || echo "Running prettier." && prettier --write "{modules,test}/**/*.js" --loglevel warn
+
+    JS_PATTERN="{modules,test,website}/**/*.js"
+    DOCS_PATTERN="docs/{overview,protocol-formats,protocol-schema}/**/*.md"
+
+    npx prettier-check "$JS_PATTERN" "$DOCS_PATTERN" || echo "Running prettier." && npx prettier --write "$JS_PATTERN" "$DOCS_PATTERN"  --loglevel warn
 
     echo "Running eslint..."
     npx eslint modules test

--- a/website/html.config.js
+++ b/website/html.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-
   title: 'XVIZ',
 
-  meta: [{
-    name: 'description',
-    content: 'Robotics Visualization Protocol'
-  }]
-
+  meta: [
+    {
+      name: 'description',
+      content: 'Robotics Visualization Protocol'
+    }
+  ]
 };

--- a/website/src/config.js
+++ b/website/src/config.js
@@ -11,12 +11,16 @@ export const HOME_HEADING = 'XVIZ Protocol';
 
 export const HOME_RIGHT = null;
 
-export const HOME_BULLETS = [{
-  text: 'Visualize autonomy and robotics data',
-  desc: 'Describe geometry, objects, and metrics that support interactive exploration of your data.'
-}, {
-  text: 'Interface controls defined along with the data',
-  desc: 'Easing development for robotics engineers and across robotic system releases.'
-}];
+export const HOME_BULLETS = [
+  {
+    text: 'Visualize autonomy and robotics data',
+    desc:
+      'Describe geometry, objects, and metrics that support interactive exploration of your data.'
+  },
+  {
+    text: 'Interface controls defined along with the data',
+    desc: 'Easing development for robotics engineers and across robotic system releases.'
+  }
+];
 
 export const ADDITIONAL_LINKS = [];

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -1,115 +1,161 @@
-export default [{
-  name: 'Documentation',
-  path: '/documentation',
-  data: [{
-    name: 'Overview',
-    children: [{
-      name: 'Introduction',
-      markdown: require('../../docs/README.md')
-    }, {
-      name: 'What\'s New',
-      markdown: require('../../CHANGELOG.md')
-    }, {
-      name: 'Versioning',
-      markdown: require('../../docs/overview/versioning.md')
-    }, {
-      name: 'Concepts',
-      markdown: require('../../docs/overview/concepts.md')
-    }, {
-      name: 'Conventions',
-      markdown: require('../../docs/overview/conventions.md')
-    }, {
-      name: 'Roadmap',
-      markdown: require('../../docs/overview/roadmap.md')
-    }, {
-      name: 'Related Projects',
-      markdown: require('../../docs/overview/related.md')
-    }]
-  }, {
-    name: 'Developer\'s Guide',
-    children: [{
-      name: 'Overview',
-      markdown: require('../../docs/developers-guide/README.md')
-    }, {
-      name: 'Installing',
-      markdown: require('../../docs/developers-guide/installing-xviz.md')
-    }, {
-      name: 'Structure of XVIZ Data',
-      markdown: require('../../docs/developers-guide/structure-of-xviz.md')
-    }, {
-      name: 'Generating XVIZ',
-      markdown: require('../../docs/developers-guide/generating-xviz.md')
-    }, {
-      name: 'Validating XVIZ',
-      markdown: require('../../docs/developers-guide/validating-xviz.md')
-    }, {
-      name: 'Serving XVIZ',
-      markdown: require('../../docs/developers-guide/serving-xviz.md')
-    }, {
-      name: 'Parsing XVIZ',
-      markdown: require('../../docs/developers-guide/parsing-xviz.md')
-    }, {
-      name: 'Styling XVIZ',
-      markdown: require('../../docs/developers-guide/styling-xviz.md')
-    }, {
-      name: 'Using the Declarative UI',
-      markdown: require('../../docs/developers-guide/using-declarative-ui.md')
-    }, {
-      name: 'Using XVIZ without JavaScript',
-      markdown: require('../../docs/developers-guide/using-xviz-in-other-languages.md')
-    }]
-  }, {
-    name: 'Protocol Schema',
-    children: [{
-      name: 'Core Protocol',
-      markdown: require('../../docs/protocol-schema/core-protocol.md')
-    }, {
-      name: 'Session Protocol',
-      markdown: require('../../docs/protocol-schema/session-protocol.md')
-    }, {
-      name: 'Geometry Primitives',
-      markdown: require('../../docs/protocol-schema/geometry-primitives.md')
-    }, {
-      name: 'Panel Specification',
-      markdown: require('../../docs/protocol-schema/panel-specification.md')
-    }, {
-      name: 'Styling Specification',
-      markdown: require('../../docs/protocol-schema/style-specification.md')
-    }]
-  }, {
-    name: 'Protocol Implementations',
-    children: [{
-      name: 'JSON Protocol',
-      markdown: require('../../docs/protocol-formats/json-protocol.md')
-    }, {
-      name: 'Binary Protocol',
-      markdown: require('../../docs/protocol-formats/binary-protocol.md')
-    }]
-  }, {
-    name: 'API Reference',
-    children: [{
-      name: 'Xviz Configuration',
-      markdown: require('../../docs/api-reference/xviz-configuration.md')
-    }, {
-      name: 'Xviz Parsing',
-      markdown: require('../../docs/api-reference/parse-xviz.md')
-    }, {
-      name: 'XvizSynchronizer',
-      markdown: require('../../docs/api-reference/xviz-synchronizer.md')
-    }, {
-      name: 'XvizLogSlice',
-      markdown: require('../../docs/api-reference/xviz-log-slice.md')
-    }, { name: 'XvizObject',
-      markdown: require('../../docs/api-reference/xviz-object.md')
-    }, {
-      name: 'XvizObjectCollection',
-      markdown: require('../../docs/api-reference/xviz-object-collection.md')
-    }, {
-      name: 'XVIZ Loader',
-      markdown: require('../../docs/api-reference/xviz-loader.md')
-    }, {
-      name: 'XVIZValidator',
-      markdown: require('../../docs/api-reference/xviz-validator.md')
-    }]
-  }] 
-}];
+export default [
+  {
+    name: 'Documentation',
+    path: '/documentation',
+    data: [
+      {
+        name: 'Overview',
+        children: [
+          {
+            name: 'Introduction',
+            markdown: require('../../docs/README.md')
+          },
+          {
+            name: "What's New",
+            markdown: require('../../CHANGELOG.md')
+          },
+          {
+            name: 'Versioning',
+            markdown: require('../../docs/overview/versioning.md')
+          },
+          {
+            name: 'Concepts',
+            markdown: require('../../docs/overview/concepts.md')
+          },
+          {
+            name: 'Conventions',
+            markdown: require('../../docs/overview/conventions.md')
+          },
+          {
+            name: 'Roadmap',
+            markdown: require('../../docs/overview/roadmap.md')
+          },
+          {
+            name: 'Related Projects',
+            markdown: require('../../docs/overview/related.md')
+          }
+        ]
+      },
+      {
+        name: "Developer's Guide",
+        children: [
+          {
+            name: 'Overview',
+            markdown: require('../../docs/developers-guide/README.md')
+          },
+          {
+            name: 'Installing',
+            markdown: require('../../docs/developers-guide/installing-xviz.md')
+          },
+          {
+            name: 'Structure of XVIZ Data',
+            markdown: require('../../docs/developers-guide/structure-of-xviz.md')
+          },
+          {
+            name: 'Generating XVIZ',
+            markdown: require('../../docs/developers-guide/generating-xviz.md')
+          },
+          {
+            name: 'Validating XVIZ',
+            markdown: require('../../docs/developers-guide/validating-xviz.md')
+          },
+          {
+            name: 'Serving XVIZ',
+            markdown: require('../../docs/developers-guide/serving-xviz.md')
+          },
+          {
+            name: 'Parsing XVIZ',
+            markdown: require('../../docs/developers-guide/parsing-xviz.md')
+          },
+          {
+            name: 'Styling XVIZ',
+            markdown: require('../../docs/developers-guide/styling-xviz.md')
+          },
+          {
+            name: 'Using the Declarative UI',
+            markdown: require('../../docs/developers-guide/using-declarative-ui.md')
+          },
+          {
+            name: 'Using XVIZ without JavaScript',
+            markdown: require('../../docs/developers-guide/using-xviz-in-other-languages.md')
+          }
+        ]
+      },
+      {
+        name: 'Protocol Schema',
+        children: [
+          {
+            name: 'Core Protocol',
+            markdown: require('../../docs/protocol-schema/core-protocol.md')
+          },
+          {
+            name: 'Session Protocol',
+            markdown: require('../../docs/protocol-schema/session-protocol.md')
+          },
+          {
+            name: 'Geometry Primitives',
+            markdown: require('../../docs/protocol-schema/geometry-primitives.md')
+          },
+          {
+            name: 'Panel Specification',
+            markdown: require('../../docs/protocol-schema/panel-specification.md')
+          },
+          {
+            name: 'Styling Specification',
+            markdown: require('../../docs/protocol-schema/style-specification.md')
+          }
+        ]
+      },
+      {
+        name: 'Protocol Implementations',
+        children: [
+          {
+            name: 'JSON Protocol',
+            markdown: require('../../docs/protocol-formats/json-protocol.md')
+          },
+          {
+            name: 'Binary Protocol',
+            markdown: require('../../docs/protocol-formats/binary-protocol.md')
+          }
+        ]
+      },
+      {
+        name: 'API Reference',
+        children: [
+          {
+            name: 'Xviz Configuration',
+            markdown: require('../../docs/api-reference/xviz-configuration.md')
+          },
+          {
+            name: 'Xviz Parsing',
+            markdown: require('../../docs/api-reference/parse-xviz.md')
+          },
+          {
+            name: 'XvizSynchronizer',
+            markdown: require('../../docs/api-reference/xviz-synchronizer.md')
+          },
+          {
+            name: 'XvizLogSlice',
+            markdown: require('../../docs/api-reference/xviz-log-slice.md')
+          },
+          {
+            name: 'XvizObject',
+            markdown: require('../../docs/api-reference/xviz-object.md')
+          },
+          {
+            name: 'XvizObjectCollection',
+            markdown: require('../../docs/api-reference/xviz-object-collection.md')
+          },
+          {
+            name: 'XVIZ Loader',
+            markdown: require('../../docs/api-reference/xviz-loader.md')
+          },
+          {
+            name: 'XVIZValidator',
+            markdown: require('../../docs/api-reference/xviz-validator.md')
+          }
+        ]
+      }
+    ]
+  }
+];


### PR DESCRIPTION
We want more consistency in our markdown docs so lets start running
prettier on some of them.  Also the website JavaScript files were left
out of the main lint and they are now included.