### PR TITLE
Declarative UI schema

### DIFF
--- a/docs/protocol-schema/declarative-ui.md
+++ b/docs/protocol-schema/declarative-ui.md
@@ -26,8 +26,8 @@ _Example skeleton UI showing how the pieces fit together_
 Layout types describe the different ways the contents of a layout element can be arranged, for
 example vertically or horizontally. Currently supported arrangement types are:
 
-- Vertical
-- Horizontal
+- Vertical (`vertical`)
+- Horizontal (`horizontal`)
 
 ### Vertical Layout
 
@@ -51,14 +51,14 @@ Layout interactions describe the ways that a layout element can be manipulated b
 interactions are completely optional, so each layout element can have zero, one, or more layout
 interactions applied to it. Currently supported layout interactions include:
 
-- Drag to Reorder
-- Drag out
+- Drag to Reorder (`reorderable`)
+- Drag out (`dragout`)
 
 ### Drag to Reorder
 
 When a layout element supports the drag to reorder interaction, it means that the elements inside of
 the layout element can be rearranged by clicking and dragging them. The formal type for drag to
-reorder is reorderable.
+reorder is `reorderable`.
 
 ### Drag Out
 
@@ -66,7 +66,7 @@ When a layout element supports the drag out interaction, it means that the compo
 components) can be moved outside of their layout element. A table, for example, could be clicked and
 dragged to free float inside the application outside of the panel that originally contained it.
 Components previously dragged out can be dragged back into the layout element that originally
-contained them. The formal type for drag out is drag_out.
+contained them. The formal type for drag out is `dragout`.
 
 ## Component Interaction Types
 
@@ -101,39 +101,45 @@ Panels are typically grouped together in tabs along the edge of an application. 
 together related pieces of data at a high level. Panels provide a convenient way for a team to group
 all of their data together.
 
-\_TODO: screentshot: panel from streetscape.gl demo app\_\_
+_TODO: screentshot: panel from streetscape.gl demo app_
 
-| **Name**     | **Type**               | **Description**                                                                                     |
-| ------------ | ---------------------- | --------------------------------------------------------------------------------------------------- |
-| name         | string                 | The name of this panel, will be displayed at the top of the panel                                   |
-| layout       | layout_type            | One of the supported layout types; defines how the elements inside of the panel should be arranged. |
-| interactions | list<interaction_type> | A list of all of the interactions supported by this panel.                                          |
-| components   | list<component_id>     | All of the components inside of this panel and the order in which they should be rendered           |
-| containers   | list<container_id>     | All of the containers inside of this panel in the order in which they should be rendered            |
+| **Name**       | **Type**                       | **Description**                                                                                          |
+| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `name`         | `string`                       | The name of this panel, will be displayed at the top of the panel                                        |
+| `layout`       | `layout_type`                  | One of the supported layout types; defines how the elements inside of the panel should be arranged.      |
+| `interactions` | `list<interaction_type>`       | A list of all of the interactions supported by this panel.                                               |
+| `children`     | `list<component OR container>` | All of the components and containers inside of this panel and the order in which they should be rendered |
 
 ### Containers
 
 Containers are used to group components together into logical groupings of information that should
-be displayed together. To some extent, they can be thought of as HTML \<div\>s. Components within
+be displayed together. To some extent, they can be thought of as HTML `<div>`s. Components within
 the container will be rendered above any other containers that are nested inside of the container.
 
-\_TODO: screentshot: panel with containers from streetscape.gl demo app\_\_
+_TODO: screentshot: panel with containers from streetscape.gl demo app_
 
-| **Name**     | **Type**                 | **Description**                                                                                     |
-| ------------ | ------------------------ | --------------------------------------------------------------------------------------------------- |
-| name         | string                   | The name of this container, will be displayed at the top of the container                           |
-| layout       | layout_type              | One of the supported layout types; defines how the elements inside of the panel should be arranged. |
-| interactions | `list<interaction_type>` | A list of all of the interactions supported by this container.                                      |
-| components   | `list<component_id>`     | All of the components inside of this container in the order that they should be rendered            |
-| containers   | `list<container_id>`     | All of the containers inside of this container in the order that they should be rendered            |
+| **Name**       | **Type**                       | **Description**                                                                                          |
+| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `name`         | `string`                       | The name of this container, will be displayed at the top of the container                                |
+| `layout`       | `layout_type`                  | One of the supported layout types; defines how the elements inside of the panel should be arranged.      |
+| `interactions` | `list<interaction_type>`       | A list of all of the interactions supported by this panel.                                               |
+| `children`     | `list<component OR container>` | All of the components and containers inside of this panel and the order in which they should be rendered |
 
 ## Components
 
 Component is the base type for all visual elements.
 
-| **Name** | **Type**               | **Description**                     |
-| -------- | ---------------------- | ----------------------------------- |
-| type     | enum{ component_type } | The explicit type of this component |
+| **Name** | **Type**                 | **Description**                     |
+| -------- | ------------------------ | ----------------------------------- |
+| `type`   | `enum{ component_type }` | The explicit type of this component |
+
+The valid values of `component_type`:
+
+- `metric`
+- `plot`
+- `table`
+- `treetable`
+- `video`
 
 ### Table
 
@@ -141,12 +147,12 @@ The Table element renders data similar to how data is presented in a traditional
 
 _TODO: screentshot: panel with table from streetscape.gl demo app_
 
-| **Name**          | **Type**  | **Description**                                                                                          |
-| ----------------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| stream            | stream_id | The stream name to populate the table data from. Must be a stream of [[LINK EM TO TreeTable] primitives. |
-| title             | string    | A title to display above the component.                                                                  |
-| description       | string    | A description of this element, displayed when hovering over the title.                                   |
-| display_object_id | boolean   | Controls whether or not the object ID column, which is automatically added to TreeTables, is displayed.  |
+| **Name**          | **Type**    | **Description**                                                                                          |
+| ----------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `stream`          | `stream_id` | The stream name to populate the table data from. Must be a stream of [[LINK EM TO TreeTable] primitives. |
+| `title`           | `string`    | A title to display above the component.                                                                  |
+| `description`     | `string`    | A description of this element, displayed when hovering over the title.                                   |
+| `displayObjectId` | `boolean`   | Controls whether or not the object ID column, which is automatically added to TreeTables, is displayed.  |
 
 #### Supported Interactions
 
@@ -163,11 +169,11 @@ _TODO: screentshot: panel with table from streetscape.gl demo app_
 {
   "components": [
     {
-      "display_object_id": true,
       "type": "table",
-      "description": "These are the details of this table",
-      "stream": "/prediction/some_table",
       "title": "A table showing something"
+      "description": "These are the details of this table",
+      "displayObjectId": true,
+      "stream": "/prediction/some_table",
     }
   ]
 }
@@ -191,19 +197,17 @@ time series data on the same chart so that data can be easily compared.
 
 _TODO: screenshot: streetscape.gl demo app showing drag-able sub-panels_
 
-| **Name**    | **Type**               | **Description**                                                                                         |
-| ----------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| streams     | map<string, stream_id> | The streams to display in the chart.. Must be a stream of [time series states TODO LINK TO TIME SERIES] |
-| title       | string                 |                                                                                                         |
-| description | string                 | Displayed when hovering over the title                                                                  |
+| **Name**      | **Type**                 | **Description**                                                                                         |
+| ------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `streams`     | `map<string, stream_id>` | The streams to display in the chart.. Must be a stream of [time series states TODO LINK TO TIME SERIES] |
+| `title`       | `string`                 |                                                                                                         |
+| `description` | `string`                 | Displayed when hovering over the title                                                                  |
 
 #### Supported Interactions
 
-**Interaction** **Description**
-
----
-
-Details on Hover When hovering over a metrics element, the
+| **Interaction**  | **Description**                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| Details on Hover | When hovering over a metrics element, the current value of the metric at the location is shown |
 
 #### JSON Example
 
@@ -211,10 +215,10 @@ Details on Hover When hovering over a metrics element, the
 {
   "components": [
     {
-      "streams": ["/some_value/actual", "/some_value/commanded"],
+      "title": "Some metric",
       "type": "metric",
       "description": "The actual vs commanded value for some variable",
-      "title": "Some metric"
+      "streams": ["/some_value/actual", "/some_value/commanded"]
     }
   ]
 }
@@ -224,12 +228,12 @@ Details on Hover When hovering over a metrics element, the
 
 ```
 components:
-  - description: The actual vs commanded value for some variable
+  - type: metric
+    title: Some metric
+    description: The actual vs commanded value for some variable
     streams:
       - /some_value/actual
       - /some_value/commanded
-    title: Some metric
-    type: metric
 ```
 
 ### Plot
@@ -237,14 +241,14 @@ components:
 The Plot component is used for showing one or more variables as a function of other another
 variable. It is useful for viewing data side-by-side.
 
-\_TODO: screenshot: streetscape.gl demo app showing normal variable plot\_\_
+_TODO: screenshot: streetscape.gl demo app showing normal variable plot_
 
-| **Name**             | **Type**        | **Description**                                                                         |
-| -------------------- | --------------- | --------------------------------------------------------------------------------------- |
-| independent_variable | stream_id       | The stream to use as the X axis.                                                        |
-| dependent_variable   | list<stream_id> | The streams to plot on the Y axis as a function of the stream that makes up the X axis. |
-| title                | string          | Shown at the top of the plot                                                            |
-| description          | string          | Displayed when hovering over the title                                                  |
+| **Name**              | **Type**          | **Description**                                                                         |
+| --------------------- | ----------------- | --------------------------------------------------------------------------------------- |
+| `independentVariable` | `stream_id`       | The stream to use as the X axis.                                                        |
+| `dependentVariable`   | `list<stream_id>` | The streams to plot on the Y axis as a function of the stream that makes up the X axis. |
+| `title`               | `string`          | Shown at the top of the plot                                                            |
+| `description`         | `string`          | Displayed when hovering over the title                                                  |
 
 #### Supported Interactions
 
@@ -259,11 +263,11 @@ variable. It is useful for viewing data side-by-side.
 {
   "components": [
     {
-      "independent_variable": "/some/stream",
-      "dependent_variables": ["/some/other_stream", "/some/second_other_stream"],
       "type": "plot",
+      "title": "Some Other Streams vs Some Stream",
       "description": "The change in some streams as a function of the other one",
-      "title": "Some Other Streams vs Some Stream"
+      "independentVariable": "/some/stream",
+      "dependentVariables": ["/some/other_stream", "/some/second_other_stream"]
     }
   ]
 }
@@ -273,14 +277,13 @@ variable. It is useful for viewing data side-by-side.
 
 ```
 components:
-  - independent_variable: /some/stream
-    dependent_variables:
+  - type: plot
+    title: Some Other Streams vs Some Stream
+    description: The change in some streams as a function of the other one
+    independentVariable: /some/stream
+    dependentVariables:
     - /some/other_stream
     - /some/second_other_stream
-    description: The change in some streams as a function of the other one
-    independent_variable: /some/stream
-    title: Some Other Streams vs Some Stream
-    type: plot
 ```
 
 ### Video
@@ -291,9 +294,9 @@ streams concurrently, multiple video elements need to be created.
 
 _TODO: screenshot: streetscape.gl demo app showing the video element_
 
-| **Name** | **Type**     | **Description**                                                                                                            |
-| -------- | ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| cameras  | list<string> | A list of the streams of video that can be rendered by this element. Only [[cameras listed - TODO link to camera metadata] |
+| **Name**  | **Type**       | **Description**                                                                                                            |
+| --------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `cameras` | `list<string>` | A list of the streams of video that can be rendered by this element. Only [[cameras listed - TODO link to camera metadata] |
 
 #### Supported Interactions
 
@@ -308,12 +311,12 @@ _TODO: screenshot: streetscape.gl demo app showing the video element_
 {
   "components": [
     {
+      "type": "video",
       "cameras": [
         "front-center-roof-camera",
         "rear-starboard-roof-camera",
         "rear-port-roof-camera"
-      ],
-      "type": "video"
+      ]
     }
   ]
 }
@@ -323,11 +326,11 @@ _TODO: screenshot: streetscape.gl demo app showing the video element_
 
 ```
 components:
-  - cameras:
+  - type: video
+    cameras:
       - front-center-roof-camera
       - rear-starboard-roof-camera
       - rear-port-roof-camera
-    type: video
 ```
 
 ### TreeTable
@@ -342,12 +345,12 @@ being collapsible.
 
 _TODO: screenshot: streetscape.gl demo app showing treetable data_
 
-| **Name**          | **Type**  | **Description**                                                                      |
-| ----------------- | --------- | ------------------------------------------------------------------------------------ |
-| stream            | stream_id | The stream of TreeTable primitives to populate with which to populate this component |
-| title             | string    | A title to display at the top of the TreeTable                                       |
-| description       | string    | A description of this component, displayed when hovering over the title.             |
-| display_object_id | boolean   | Whether or not to display the object ID column                                       |
+| **Name**            | **Type**    | **Description**                                                                      |
+| ------------------- | ----------- | ------------------------------------------------------------------------------------ |
+| `stream`            | `stream_id` | The stream of TreeTable primitives to populate with which to populate this component |
+| `title`             | `string`    | A title to display at the top of the TreeTable                                       |
+| `description`       | `string`    | A description of this component, displayed when hovering over the title.             |
+| `display_object_id` | `boolean`   | Whether or not to display the object ID column                                       |
 
 #### Supported Interactions
 
@@ -393,70 +396,78 @@ Below is a complete example of what a panel definition would look like
 
 ```
 {
-  "containers": [
-    {
-      "containers": [],
-      "layout": "horizontal",
-      "name": "Example Container #1",
-      "components": [
-        {
-          "display_object_id": false,
-          "type": "table",
-          "description": "These are the details of this table",
-          "stream": "/some/table_stream",
-          "title": "A nested table showing something"
-        },
-        {
-          "independent_variable": "/some/stream",
-          "title": "A nested plot!",
-          "dependent_variables": ["/some/other_stream", "/some/second_other_stream"],
-          "description": "The change in some streams as a function of the other one",
-          "type": "plot"
-        }
-      ],
-      "interactions": ["drag_out"]
-    }
-  ],
+  "type": "panel",
   "layout": "vertical",
   "name": "Example Panel",
-  "components": [
+  "interactions": ["reorderable"],
+  "children": [
     {
-      "display_object_id": true,
+      "type": "container",
+      "layout": "horizontal",
+      "name": "Example Container #1",
+      "interactions": ["dragout"],
+      "children": [
+        {
+          "type": "table",
+          "title": "A nested table showing something",
+          "description": "These are the details of this table",
+          "stream": "/some/table_stream",
+          "displayObjectId": false
+        },
+        {
+          "type": "plot",
+          "title": "A nested plot!",
+          "description": "The change in some streams as a function of the other one",
+          "independentVariable": "/some/stream",
+          "dependentVariable": [
+            "/some/other_stream",
+            "/some/second_other_stream"
+          ]
+        }
+      ]
+    },
+    {
       "type": "table",
+      "title": "A table showing something",
       "description": "These are the details of this table",
-      "stream": "/prediction/some_table",
-      "title": "A table showing something"
+      "displayObjectId": true,
+      "stream": "/prediction/some_table"
     },
     {
-      "streams": ["/some_value/actual", "/some_value/commanded"],
       "type": "metric",
+      "title": "Some metric",
       "description": "The actual vs commanded value for some variable",
-      "title": "Some metric"
+      "streams": [
+        "/some_value/actual",
+        "/some_value/commanded"
+      ]
     },
     {
-      "independent_variable": "/some/stream",
-      "dependent_variables": ["/some/other_stream", "/some/second_other_stream"],
       "type": "plot",
+      "title": "Some Other Streams vs Some Stream",
       "description": "The change in some streams as a function of the other one",
-      "title": "Some Other Streams vs Some Stream"
+      "independentVariable": "/some/stream",
+      "dependentVariable": [
+        "/some/other_stream",
+        "/some/second_other_stream"
+      ]
     },
     {
+      "type": "video",
       "cameras": [
         "front-center-roof-camera",
         "rear-starboard-roof-camera",
         "rear-port-roof-camera"
-      ],
-      "type": "video"
+      ]
     },
     {
-      "display_object_id": false,
-      "type": "tree_table",
+      "type": "treetable",
+      "title": "A TreeTable!",
       "description": "These are the details of the TreeTable",
-      "stream": "/some/stream/of/treetable/primmatives",
-      "title": "A TreeTable!"
+      "displayObjectId": false,
+      "stream": "/some/stream/of/treetable/primmatives"
     }
-  ],
-  "interactions": ["reorderable"]
+  ]
 }
 ```
 

--- a/modules/schema/declarative-ui/component_base.schema.json
+++ b/modules/schema/declarative-ui/component_base.schema.json
@@ -1,0 +1,16 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/component_base.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    }
+  }
+}

--- a/modules/schema/declarative-ui/components/_tabular.schema.json
+++ b/modules/schema/declarative-ui/components/_tabular.schema.json
@@ -1,0 +1,18 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/components/_tabular.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{ "$ref": "https://xviz.org/schema/declarative-ui/component_base.json" }],
+  "properties": {
+    "stream": {
+      "type": "string"
+    },
+    "displayObjectId": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "type",
+    "title",
+    "stream"
+  ]
+}

--- a/modules/schema/declarative-ui/components/metric.schema.json
+++ b/modules/schema/declarative-ui/components/metric.schema.json
@@ -1,0 +1,26 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/components/metric.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{ "$ref": "https://xviz.org/schema/declarative-ui/component_base.json" }],
+  "properties": {
+    "type": {
+      "enum": ["metric"]
+    },
+    "title": {},
+    "description": {},
+    "streams": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "additionalItems": false
+    }
+  },
+  "required": [
+    "type",
+    "title",
+    "streams"
+  ],
+  "additionalProperties": false
+}

--- a/modules/schema/declarative-ui/components/plot.schema.json
+++ b/modules/schema/declarative-ui/components/plot.schema.json
@@ -1,0 +1,30 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/components/plot.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{ "$ref": "https://xviz.org/schema/declarative-ui/component_base.json" }],
+  "properties": {
+    "type": {
+      "enum": ["plot"]
+    },
+    "title": {},
+    "description": {},
+    "independentVariable": {
+      "type": "string"
+    },
+    "dependentVariable": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "additionalItems": false
+    }
+  },
+  "required": [
+    "type",
+    "title",
+    "independentVariable",
+    "dependentVariable"
+  ],
+  "additionalProperties": false
+}

--- a/modules/schema/declarative-ui/components/table.schema.json
+++ b/modules/schema/declarative-ui/components/table.schema.json
@@ -1,0 +1,15 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/components/table.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{ "$ref": "https://xviz.org/schema/declarative-ui/components/_tabular.json" }],
+  "properties": {
+    "type": {
+      "enum": ["table"]
+    },
+    "title": {},
+    "description": {},
+    "stream": {},
+    "displayObjectId": {}
+  },
+  "additionalProperties": false
+}

--- a/modules/schema/declarative-ui/components/treetable.schema.json
+++ b/modules/schema/declarative-ui/components/treetable.schema.json
@@ -1,0 +1,15 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/components/treetable.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{ "$ref": "https://xviz.org/schema/declarative-ui/components/_tabular.json" }],
+  "properties": {
+    "type": {
+      "enum": ["treetable"]
+    },
+    "title": {},
+    "description": {},
+    "stream": {},
+    "displayObjectId": {}
+  },
+  "additionalProperties": false
+}

--- a/modules/schema/declarative-ui/components/video.schema.json
+++ b/modules/schema/declarative-ui/components/video.schema.json
@@ -1,0 +1,25 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/components/video.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{ "$ref": "https://xviz.org/schema/declarative-ui/component_base.json" }],
+  "properties": {
+    "type": {
+      "enum": ["video"]
+    },
+    "title": {},
+    "description": {},
+    "cameras": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "additionalItems": false
+    }
+  },
+  "required": [
+    "type",
+    "cameras"
+  ],
+  "additionalProperties": false
+}

--- a/modules/schema/declarative-ui/panel.schema.json
+++ b/modules/schema/declarative-ui/panel.schema.json
@@ -1,0 +1,80 @@
+{
+  "id": "https://xviz.org/schema/declarative-ui/panel.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Declarative UI Panel Info",
+  "allOf": [{ "$ref": "#/definitions/with_children" }],
+  "properties": {
+    "type": {
+      "enum": ["panel"]
+    },
+    "name": {},
+    "layout": {},
+    "interactions": {},
+    "children": {}
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "with_children": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "layout": {
+          "type": "string",
+          "enum": ["vertical", "horizontal"]
+        },
+        "interactions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "reorderable",
+              "dragout"
+            ]
+          },
+          "additionalItems": false
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {"$ref": "https://xviz.org/schema/declarative-ui/components/metric.json"},
+              {"$ref": "https://xviz.org/schema/declarative-ui/components/plot.json"},
+              {"$ref": "https://xviz.org/schema/declarative-ui/components/table.json"},
+              {"$ref": "https://xviz.org/schema/declarative-ui/components/treetable.json"},
+              {"$ref": "https://xviz.org/schema/declarative-ui/components/video.json"},
+              {"$ref": "#/definitions/container"}
+            ]
+          },
+          "additionalItems": false
+        }
+      },
+      "required": [
+        "name",
+        "children"
+      ]
+    },
+    "container": {
+      "title": "container",
+      "description": "Group of components",
+      "allOf": [{ "$ref": "#/definitions/with_children" }],
+      "properties": {
+        "type": {
+          "enum": ["container"]
+        },
+        "name": {},
+        "layout": {},
+        "interactions": {},
+        "children": {}
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/modules/schema/examples/declarative-ui/components/metric/multiple_stream.json
+++ b/modules/schema/examples/declarative-ui/components/metric/multiple_stream.json
@@ -1,0 +1,8 @@
+{
+  "type": "metric",
+  "title": "Velocity vs. Accelerator Input",
+  "streams": [
+    "/vehicle/velocity",
+    "/vehicle/accelerator"
+  ]
+}

--- a/modules/schema/examples/declarative-ui/components/metric/single_stream.json
+++ b/modules/schema/examples/declarative-ui/components/metric/single_stream.json
@@ -1,0 +1,5 @@
+{
+  "type": "metric",
+  "title": "Velocity",
+  "streams": ["/vehicle/velocity"]
+}

--- a/modules/schema/examples/declarative-ui/components/plot/simple.json
+++ b/modules/schema/examples/declarative-ui/components/plot/simple.json
@@ -1,0 +1,10 @@
+{
+  "type": "plot",
+  "title": "Some Other Streams vs Some Stream",
+  "description": "The change in some streams as a function of the other one",
+  "independentVariable": "/some/stream",
+  "dependentVariable": [
+    "/some/other_stream",
+    "/some/second_other_stream"
+  ]
+}

--- a/modules/schema/examples/declarative-ui/components/table/complete.json
+++ b/modules/schema/examples/declarative-ui/components/table/complete.json
@@ -1,0 +1,7 @@
+{
+  "type": "table",
+  "title": "A table showing something",
+  "description": "These are the details of this table",
+  "displayObjectId": true,
+  "stream": "/prediction/some_table"
+}

--- a/modules/schema/examples/declarative-ui/components/table/noId.json
+++ b/modules/schema/examples/declarative-ui/components/table/noId.json
@@ -1,0 +1,6 @@
+{
+  "type": "table",
+  "title": "A table showing something",
+  "description": "These are the details of this table",
+  "stream": "/prediction/some_table"
+}

--- a/modules/schema/examples/declarative-ui/components/treetable/complete.json
+++ b/modules/schema/examples/declarative-ui/components/treetable/complete.json
@@ -1,0 +1,7 @@
+{
+  "type": "treetable",
+  "title": "A Tree Table showing something",
+  "description": "These are the details of this tree table",
+  "displayObjectId": true,
+  "stream": "/prediction/some_treetable"
+}

--- a/modules/schema/examples/declarative-ui/components/video/multi_camera.json
+++ b/modules/schema/examples/declarative-ui/components/video/multi_camera.json
@@ -1,0 +1,8 @@
+{
+  "type": "video",
+  "cameras": [
+    "front-center-roof-camera",
+    "rear-starboard-roof-camera",
+    "rear-port-roof-camera"
+  ]
+}

--- a/modules/schema/examples/declarative-ui/components/video/single_camera.json
+++ b/modules/schema/examples/declarative-ui/components/video/single_camera.json
@@ -1,0 +1,6 @@
+{
+  "type": "video",
+  "cameras": [
+    "front-center-roof-camera"
+  ]
+}

--- a/modules/schema/examples/declarative-ui/panel/complete.json
+++ b/modules/schema/examples/declarative-ui/panel/complete.json
@@ -1,0 +1,74 @@
+{
+  "type": "panel",
+  "layout": "vertical",
+  "name": "Example Panel",
+  "interactions": ["reorderable"],
+  "children": [
+    {
+      "type": "container",
+      "layout": "horizontal",
+      "name": "Example Container #1",
+      "interactions": ["dragout"],
+      "children": [
+        {
+          "type": "table",
+          "title": "A nested table showing something",
+          "description": "These are the details of this table",
+          "stream": "/some/table_stream",
+          "displayObjectId": false
+        },
+        {
+          "type": "plot",
+          "title": "A nested plot!",
+          "description": "The change in some streams as a function of the other one",
+          "independentVariable": "/some/stream",
+          "dependentVariable": [
+            "/some/other_stream",
+            "/some/second_other_stream"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "A table showing something",
+      "description": "These are the details of this table",
+      "displayObjectId": true,
+      "stream": "/prediction/some_table"
+    },
+    {
+      "type": "metric",
+      "title": "Some metric",
+      "description": "The actual vs commanded value for some variable",
+      "streams": [
+        "/some_value/actual",
+        "/some_value/commanded"
+      ]
+    },
+    {
+      "type": "plot",
+      "title": "Some Other Streams vs Some Stream",
+      "description": "The change in some streams as a function of the other one",
+      "independentVariable": "/some/stream",
+      "dependentVariable": [
+        "/some/other_stream",
+        "/some/second_other_stream"
+      ]
+    },
+    {
+      "type": "video",
+      "cameras": [
+        "front-center-roof-camera",
+        "rear-starboard-roof-camera",
+        "rear-port-roof-camera"
+      ]
+    },
+    {
+      "type": "treetable",
+      "title": "A TreeTable!",
+      "description": "These are the details of the TreeTable",
+      "displayObjectId": false,
+      "stream": "/some/stream/of/treetable/primmatives"
+    }
+  ]
+}

--- a/modules/schema/examples/declarative-ui/panel/container.json
+++ b/modules/schema/examples/declarative-ui/panel/container.json
@@ -1,0 +1,22 @@
+{
+  "type": "panel",
+  "name": "Metrics Panel",
+  "children": [
+    {
+      "type": "container",
+      "name": "Metrics Container 1",
+      "children": [
+        {
+          "type": "metric",
+          "streams": ["/vehicle/velocity"],
+          "title": "Velocity"
+        },
+        {
+          "type": "metric",
+          "streams": ["/vehicle/acceleration"],
+          "title": "Acceleration"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/schema/examples/declarative-ui/panel/mixed.json
+++ b/modules/schema/examples/declarative-ui/panel/mixed.json
@@ -1,0 +1,22 @@
+{
+  "type": "panel",
+  "name": "Metrics Panel",
+  "children": [
+    {
+      "type": "container",
+      "name": "Metrics Container 1",
+      "children": [
+        {
+          "type": "metric",
+          "streams": ["/vehicle/velocity"],
+          "title": "Velocity"
+        }
+      ]
+    },
+    {
+      "type": "metric",
+      "streams": ["/vehicle/acceleration"],
+      "title": "Acceleration"
+    }
+  ]
+}

--- a/modules/schema/examples/declarative-ui/panel/multi_component.json
+++ b/modules/schema/examples/declarative-ui/panel/multi_component.json
@@ -1,0 +1,16 @@
+{
+  "type": "panel",
+  "name": "One",
+  "children": [
+    {
+      "type": "metric",
+      "streams": ["/vehicle/velocity"],
+      "title": "Velocity"
+    },
+    {
+      "type": "metric",
+      "streams": ["/vehicle/acceleration"],
+      "title": "Acceleration"
+    }
+  ]
+}

--- a/modules/schema/examples/declarative-ui/panel/nested_container.json
+++ b/modules/schema/examples/declarative-ui/panel/nested_container.json
@@ -1,0 +1,38 @@
+{
+  "type": "panel",
+  "name": "Metrics Panel",
+  "children": [
+    {
+      "type": "container",
+      "name": "Metrics Container 1",
+      "children": [
+        {
+          "type": "container",
+          "name": "Sub Container",
+          "children": [
+            {
+              "type": "metric",
+              "streams": ["/vehicle/temp/inside"],
+              "title": "Inside Temp"
+            },
+            {
+              "type": "metric",
+              "streams": ["/vehicle/temp/output"],
+              "title": "Outside Temp"
+            }
+          ]
+        },
+        {
+          "type": "metric",
+          "streams": ["/vehicle/velocity"],
+          "title": "Velocity"
+        },
+        {
+          "type": "metric",
+          "streams": ["/vehicle/acceleration"],
+          "title": "Acceleration"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/schema/examples/declarative-ui/panel/single_component.json
+++ b/modules/schema/examples/declarative-ui/panel/single_component.json
@@ -1,0 +1,11 @@
+{
+  "type": "panel",
+  "name": "One",
+  "children": [
+    {
+      "type": "metric",
+      "streams": ["/vehicle/velocity"],
+      "title": "Velocity"
+    }
+  ]
+}

--- a/modules/schema/genimports.js
+++ b/modules/schema/genimports.js
@@ -34,6 +34,7 @@ function loadAllSchemas(schemaDir) {
             const cleanedPath = relPath
               .replace(/\//g, '_')
               .replace(/\./g, '_')
+              .replace(/-/g, '_')
               .replace(/__/g, '_');
             const identifier = snakeToCamel(cleanedPath);
             schemaMap[identifier] = {

--- a/modules/schema/invalid/declarative-ui/components/metric/bad_title.json
+++ b/modules/schema/invalid/declarative-ui/components/metric/bad_title.json
@@ -1,0 +1,5 @@
+{
+  "type": "metric",
+  "title": 1,
+  "streams": ["/vehicle/velocity"]
+}

--- a/modules/schema/invalid/declarative-ui/components/metric/bad_type.json
+++ b/modules/schema/invalid/declarative-ui/components/metric/bad_type.json
@@ -1,0 +1,5 @@
+{
+  "type": "not a valid type",
+  "title": "Velocity",
+  "streams": ["/vehicle/velocity"]
+}

--- a/modules/schema/invalid/declarative-ui/components/metric/no_streams.json
+++ b/modules/schema/invalid/declarative-ui/components/metric/no_streams.json
@@ -1,0 +1,5 @@
+{
+  "type": "metric",
+  "title": "Test test",
+  "streams": []
+}

--- a/modules/schema/invalid/declarative-ui/components/table/no_type.json
+++ b/modules/schema/invalid/declarative-ui/components/table/no_type.json
@@ -1,0 +1,6 @@
+{
+  "title": "A table showing something",
+  "description": "These are the details of this table",
+  "displayObjectId": true,
+  "stream": "/prediction/some_table"
+}

--- a/modules/schema/invalid/declarative-ui/panel/bad_name.json
+++ b/modules/schema/invalid/declarative-ui/panel/bad_name.json
@@ -1,0 +1,11 @@
+{
+  "type": "panel",
+  "name": 1,
+  "children": [
+    {
+      "type": "metric",
+      "streams": ["/vehicle/velocity"],
+      "title": "Velocity"
+    }
+  ]
+}

--- a/modules/schema/invalid/declarative-ui/panel/bad_type_children.json
+++ b/modules/schema/invalid/declarative-ui/panel/bad_type_children.json
@@ -1,0 +1,17 @@
+{
+  "type": "panel",
+  "name": "Metrics Panel",
+  "children": [
+    {
+      "type": "container",
+      "name": "Metrics Container 1",
+      "children": [
+        {
+          "type": "doesnotexist",
+          "streams": ["/vehicle/velocity"],
+          "title": "Velocity"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/schema/invalid/declarative-ui/panel/missing_container_name.json
+++ b/modules/schema/invalid/declarative-ui/panel/missing_container_name.json
@@ -1,0 +1,16 @@
+{
+  "type": "panel",
+  "name": "Metrics Panel",
+  "children": [
+    {
+      "type": "container",
+      "children": [
+        {
+          "type": "metric",
+          "streams": ["/vehicle/velocity"],
+          "title": "Velocity"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/schema/invalid/declarative-ui/panel/missing_name.json
+++ b/modules/schema/invalid/declarative-ui/panel/missing_name.json
@@ -1,0 +1,10 @@
+{
+  "type": "panel",
+  "children": [
+    {
+      "type": "metric",
+      "streams": ["/vehicle/velocity"],
+      "title": "Velocity"
+    }
+  ]
+}

--- a/modules/schema/invalid/declarative-ui/panel/wrong_type.json
+++ b/modules/schema/invalid/declarative-ui/panel/wrong_type.json
@@ -1,0 +1,17 @@
+{
+  "type": "panel",
+  "name": "Metrics Panel",
+  "children": [
+    {
+      "type": "bar",
+      "name": "Metrics Container 1",
+      "children": [
+        {
+          "type": "metric",
+          "streams": ["/vehicle/velocity"],
+          "title": "Velocity"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/schema/src/data.js
+++ b/modules/schema/src/data.js
@@ -14,6 +14,14 @@ import coreTimeseriesStateSchemaJson from '../core/timeseries_state.schema.json'
 import coreValueSchemaJson from '../core/value.schema.json';
 import coreVariableSchemaJson from '../core/variable.schema.json';
 import coreVariableStateSchemaJson from '../core/variable_state.schema.json';
+import declarativeUiComponentBaseSchemaJson from '../declarative-ui/component_base.schema.json';
+import declarativeUiComponentsMetricSchemaJson from '../declarative-ui/components/metric.schema.json';
+import declarativeUiComponentsPlotSchemaJson from '../declarative-ui/components/plot.schema.json';
+import declarativeUiComponentsTableSchemaJson from '../declarative-ui/components/table.schema.json';
+import declarativeUiComponentsTabularSchemaJson from '../declarative-ui/components/_tabular.schema.json';
+import declarativeUiComponentsTreetableSchemaJson from '../declarative-ui/components/treetable.schema.json';
+import declarativeUiComponentsVideoSchemaJson from '../declarative-ui/components/video.schema.json';
+import declarativeUiPanelSchemaJson from '../declarative-ui/panel.schema.json';
 import mathMatrix3x3SchemaJson from '../math/matrix3x3.schema.json';
 import mathMatrix4x4SchemaJson from '../math/matrix4x4.schema.json';
 import mathPoint3dListSchemaJson from '../math/point3d_list.schema.json';
@@ -51,6 +59,14 @@ export const SCHEMA_DATA = {
   'core/value.schema.json': coreValueSchemaJson,
   'core/variable.schema.json': coreVariableSchemaJson,
   'core/variable_state.schema.json': coreVariableStateSchemaJson,
+  'declarative-ui/component_base.schema.json': declarativeUiComponentBaseSchemaJson,
+  'declarative-ui/components/metric.schema.json': declarativeUiComponentsMetricSchemaJson,
+  'declarative-ui/components/plot.schema.json': declarativeUiComponentsPlotSchemaJson,
+  'declarative-ui/components/table.schema.json': declarativeUiComponentsTableSchemaJson,
+  'declarative-ui/components/_tabular.schema.json': declarativeUiComponentsTabularSchemaJson,
+  'declarative-ui/components/treetable.schema.json': declarativeUiComponentsTreetableSchemaJson,
+  'declarative-ui/components/video.schema.json': declarativeUiComponentsVideoSchemaJson,
+  'declarative-ui/panel.schema.json': declarativeUiPanelSchemaJson,
   'math/matrix3x3.schema.json': mathMatrix3x3SchemaJson,
   'math/matrix4x4.schema.json': mathMatrix4x4SchemaJson,
   'math/point3d_list.schema.json': mathPoint3dListSchemaJson,


### PR DESCRIPTION
This lets us validate declarative UI content before it gets sent to
the front end.  Right now we are just going with camel case to match
the existing builders.

Declarative UI itself lets you generate panels from your XVIZ data
with no custom code.