### PR TITLE
Fix passing json to isBinaryXVIZ

### DIFF
--- a/modules/parser/src/loaders/xviz-loader/xviz-binary-loader.js
+++ b/modules/parser/src/loaders/xviz-loader/xviz-binary-loader.js
@@ -8,5 +8,6 @@ export function parseBinaryXVIZ(arrayBuffer) {
 }
 
 export function isBinaryXVIZ(arrayBuffer) {
-  return isGLB(arrayBuffer, {magic: MAGIC_XVIZ});
+  const isArrayBuffer = arrayBuffer instanceof ArrayBuffer;
+  return isArrayBuffer && isGLB(arrayBuffer, {magic: MAGIC_XVIZ});
 }


### PR DESCRIPTION
Fix issue here: https://github.com/uber/xviz/issues/165
Tested by copying the build parser file into monorepo, run av-log-viewer, and teleassist-web unit test also pass