### PR TITLE
Update parsed XVIZ flow to account for protobuf related schema changes

### DIFF
--- a/docs/api-reference/xviz-builder.md
+++ b/docs/api-reference/xviz-builder.md
@@ -226,12 +226,13 @@ const frame = xvizBuider.getFrame();
       }
       primitives: {
         '/point-cloud': {
-          primitives: [
+          points: [
             {
-              style: {
-                fill_color: [255,0,0]
+              base: {
+                style: {
+                  fill_color: [255,0,0]
+                }
               },
-              type: 'points',
               vertices: [1.23, 0.45, 0.06]
             }
           ]

--- a/docs/protocol-schema/core-protocol.md
+++ b/docs/protocol-schema/core-protocol.md
@@ -282,9 +282,10 @@ As an example in JSON of a `point` primitive using style classes:
 
 ```js
 {
-    "type": "polygon",
-    "id": "178beda89169420cbb876c14acdba7f8",
-    "classes": ["car", "important"]
+    "base": {
+      "object_id": "178beda89169420cbb876c14acdba7f8",
+      "classes": ["car", "important"]
+    },
     "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
 ```
@@ -294,11 +295,12 @@ information for each object over and over. Here is what it looks like to use an 
 
 ```js
 {
-    "type": "polygon",
-    "id": "178beda89169420cbb876c14acdba7f8",
-    "style": {
-        "fill_color": "#FF0000",
-        "stroke_color": "#000080"
+    "base": {
+      "object_id": "178beda89169420cbb876c14acdba7f8",
+      "style": {
+          "fill_color": "#FF0000",
+          "stroke_color": "#000080"
+      }
     },
     "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }

--- a/docs/protocol-schema/geometry-primitives.md
+++ b/docs/protocol-schema/geometry-primitives.md
@@ -33,7 +33,6 @@ Example:
 
 ```
 {
-    "type": "point",
     "points": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
 ```
@@ -50,7 +49,6 @@ JSON example using style class for styling:
 
 ```
 {
-    "type": "polygon",
     "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
 ```
@@ -67,7 +65,6 @@ JSON example using style class for styling:
 
 ```
 {
-    "type": "polyline",
     "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
 ```
@@ -85,7 +82,6 @@ Example:
 
 ```
 {
-    "type": "circle",
     "center": [9, 15, 3],
     "radius_m": 2.5
 }
@@ -106,7 +102,6 @@ Example:
 
 ```
 {
-    "type": "stadium",
     "start": [9, 15, 3],
     "end": [20, 13, 3],
     "radius_m": 2.5
@@ -127,7 +122,6 @@ Example:
 
 ```
 {
-    "type": "text",
     "position": [9, 15, 3],
     "text": "Location of interest"
 }
@@ -149,7 +143,6 @@ stores the raw image directly instead of needing to base64 encode it.
 
 ```
 {
-    "type": "image,
     "position": [9, 15, 3],
     "data": "/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",
     "width_px": 1280,

--- a/modules/builder/src/writers/xviz-writer/xviz-json-encoder.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-json-encoder.js
@@ -6,7 +6,7 @@ import base64js from 'base64-js';
 /* eslint-disable complexity */
 export function xvizConvertJson(object, keyName) {
   if (Array.isArray(object)) {
-    return object.map(element => xvizConvertJson(element));
+    return object.map(element => xvizConvertJson(element, keyName));
   }
 
   // Typed arrays become normal arrays
@@ -36,7 +36,7 @@ export function xvizConvertJson(object, keyName) {
   if (object !== null && typeof object === 'object') {
     // Handle XVIZ Image Primitive
     const properties = Object.keys(object);
-    if (['type', 'data'].every(prop => properties.includes(prop)) && object.type === 'image') {
+    if (properties.includes('data') && keyName === 'images') {
       return {
         ...object,
         data: base64js.fromByteArray(object.data)
@@ -46,7 +46,7 @@ export function xvizConvertJson(object, keyName) {
     // Handle all other objects
     const newObject = {};
     for (const key in object) {
-      newObject[key] = xvizConvertJson(object[key], key);
+      newObject[key] = xvizConvertJson(object[key], key, keyName);
     }
     return newObject;
   }

--- a/modules/parser/src/parsers/parse-timeslice-data-v2.js
+++ b/modules/parser/src/parsers/parse-timeslice-data-v2.js
@@ -91,7 +91,7 @@ function parseStateUpdates(stateUpdates, timestamp, convertPrimitive) {
     .filter(streamName => !STREAM_BLACKLIST.has(streamName))
     .forEach(primitive => {
       newStreams[primitive] = parseStreamPrimitive(
-        primitives[primitive].primitives,
+        primitives[primitive],
         primitive,
         timestamp,
         convertPrimitive

--- a/modules/parser/src/parsers/parse-xviz-primitive.js
+++ b/modules/parser/src/parsers/parse-xviz-primitive.js
@@ -4,6 +4,7 @@ export function normalizeXvizPrimitive(
   primitive,
   objectIndex,
   streamName,
+  type,
   time,
   postProcessPrimitive
 ) {
@@ -11,16 +12,17 @@ export function normalizeXvizPrimitive(
   // it is intentional to mutate the primitive in place
   // to avoid frequent allocate/discard and improve performance
 
+  // Type could come set (v2 metadata or object, or v1 inline)
+  const primitiveType = type || primitive.type;
+
   const {
-    // common
-    type,
     // line2d, polygon2d
     vertices,
     // circle2d
     center
   } = primitive;
 
-  const {enableZOffset, validate, normalize} = PRIMITIVE_PROCCESSOR[type];
+  const {enableZOffset, validate, normalize} = PRIMITIVE_PROCCESSOR[primitiveType];
 
   // Apply a small offset to 2d geometries to battle z fighting
   if (enableZOffset) {
@@ -37,6 +39,11 @@ export function normalizeXvizPrimitive(
     if (center && center.length === 2) {
       center[2] = zOffset;
     }
+  }
+
+  // add 'type' if not present at root level of primitive
+  if (primitiveType) {
+    primitive.type = primitiveType;
   }
 
   // validate

--- a/modules/parser/src/parsers/parse-xviz-stream.js
+++ b/modules/parser/src/parsers/parse-xviz-stream.js
@@ -2,6 +2,7 @@ import {getXvizConfig} from '../config/xviz-config';
 import {normalizeXvizPrimitive} from './parse-xviz-primitive';
 import XvizObject from '../objects/xviz-object';
 import {isMainThread} from '../utils/globals';
+import {getPrimitiveData} from './xviz-v2-common';
 
 export const PRIMITIVE_CAT = {
   LOOKAHEAD: 'lookAheads',
@@ -61,17 +62,21 @@ export function parseXvizStream(data, convertPrimitive) {
 /* Processes an individual primitive time sample and converts the
  * data to UI elements.
  */
-export function parseStreamPrimitive(objects, streamName, time, convertPrimitive) {
+export function parseStreamPrimitive(primitives, streamName, time, convertPrimitive) {
   const {OBJECT_STREAM, preProcessPrimitive, PRIMITIVE_SETTINGS} = getXvizConfig();
 
-  if (!Array.isArray(objects)) {
+  const primitiveData = getPrimitiveData(primitives);
+
+  if (!primitiveData || !Array.isArray(primitiveData.primitives)) {
     return {};
   }
 
+  const {type: primType, primitives: objects} = primitiveData;
+
   if (isMainThread && streamName === OBJECT_STREAM) {
     for (const object of objects) {
-      // v1: id, v2: object_id
-      XvizObject.observe(object.id || object.object_id, time);
+      // v1: id, v2: base.object_id
+      XvizObject.observe(object.id || (object.base && object.base.object_id), time);
     }
   }
   const primitiveMap = createPrimitiveMap();
@@ -96,6 +101,7 @@ export function parseStreamPrimitive(objects, streamName, time, convertPrimitive
           object[j],
           objectIndex,
           streamName,
+          primType,
           time,
           convertPrimitive
         );
@@ -110,12 +116,13 @@ export function parseStreamPrimitive(objects, streamName, time, convertPrimitive
       preProcessPrimitive({primitive: object, streamName, time});
 
       // normalize primitive
-      category = PRIMITIVE_SETTINGS[object.type].category;
+      category = PRIMITIVE_SETTINGS[primType].category;
       const primitive = normalizeXvizPrimitive(
         PRIMITIVE_SETTINGS,
         object,
         objectIndex,
         streamName,
+        primType,
         time,
         convertPrimitive
       );
@@ -140,31 +147,29 @@ export function parseStreamFutures(objects, streamName, time, convertPrimitive) 
   // objects = array of objects
   // [{timestamp, primitives[]}, ...]
 
-  // Futures are an array of array of primitives
-  // TODO(twojtasz): objects indexes represent the
-  //     represent an index into time, so they cannot be removed
-  //     if empty.
+  // Futures are an array of array of primitives and
+  // the objectIndex is used to find the timestamp associated
+  // with the set of primitives.
   objects.forEach((object, objectIndex) => {
-    const {primitives} = object;
-
-    // TODO(twojtasz): only geometric primitives are supported
-    // for now.  Text and point clouds are not handled
-    // TODO(twojtasz): addThickness is temporary to use XVIZ thickness
-    //                 on polygons.
-    const future = primitives
-      .map(primitive =>
-        normalizeXvizPrimitive(
-          PRIMITIVE_SETTINGS,
-          primitive,
-          objectIndex,
-          streamName,
-          time,
-          convertPrimitive
+    const data = getPrimitiveData(object);
+    if (data) {
+      const {type, primitives} = data;
+      const future = primitives
+        .map(primitive =>
+          normalizeXvizPrimitive(
+            PRIMITIVE_SETTINGS,
+            primitive,
+            objectIndex,
+            streamName,
+            type,
+            time,
+            convertPrimitive
+          )
         )
-      )
-      .filter(Boolean);
+        .filter(Boolean);
 
-    futures.push(future);
+      futures.push(future);
+    }
   });
 
   return {

--- a/modules/parser/src/parsers/xviz-primitives-v2.js
+++ b/modules/parser/src/parsers/xviz-primitives-v2.js
@@ -3,15 +3,19 @@ import {filterVertices} from './filter-vertices';
 import {PRIMITIVE_CAT} from './parse-xviz-stream';
 import base64js from 'base64-js';
 
+function aliasId(primitive) {
+  if (primitive && primitive.base && primitive.base.object_id) {
+    primitive.id = primitive.base.object_id;
+  }
+}
+
 // TODO - tests for all primitive types
 export default {
   text: {
     category: PRIMITIVE_CAT.FEATURE,
     validate: primitive => true,
     normalize: primitive => {
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
+      aliasId(primitive);
     }
   },
   // eslint-disable-next-line camelcase
@@ -19,18 +23,14 @@ export default {
     category: PRIMITIVE_CAT.COMPONENT,
     validate: primitive => true,
     normalize: primitive => {
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
+      aliasId(primitive);
     }
   },
   circle: {
     category: PRIMITIVE_CAT.FEATURE,
     validate: (primitive, streamName, time) => primitive.center,
     normalize: primitive => {
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
+      aliasId(primitive);
     }
   },
   polyline: {
@@ -45,9 +45,7 @@ export default {
       // in the path layer
       // TODO - handle this directly in deck.gl PathLayer
       primitive.vertices = filterVertices(primitive.vertices);
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
+      aliasId(primitive);
     }
   },
   polygon: {
@@ -60,9 +58,7 @@ export default {
       // from XVIS is never closed - worst case we end up with a duplicate end vertex,
       // which will not break the polygon layer.
       primitive.vertices.push(primitive.vertices[0]);
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
+      aliasId(primitive);
     }
   },
   point: {
@@ -71,9 +67,7 @@ export default {
     normalize: primitive => {
       // Alias XVIZ 2.0 to normalized vertices field.
       primitive.vertices = primitive.points;
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
+      aliasId(primitive);
     }
   },
   image: {
@@ -84,15 +78,14 @@ export default {
       if (typeof primitive.data === 'string') {
         imageData = base64js.toByteArray(imageData);
       }
+      // format is not part of v2 spec
       const imgType = primitive.format ? `image/${primitive.format}` : null;
       const blob = new Blob([imageData], {type: imgType});
       primitive.imageUrl = URL.createObjectURL(blob);
-      if (primitive.object_id) {
-        primitive.id = primitive.object_id;
-      }
       if (primitive.position) {
         primitive.vertices = primitive.position;
       }
+      aliasId(primitive);
     }
   }
 };

--- a/modules/parser/src/parsers/xviz-v2-common.js
+++ b/modules/parser/src/parsers/xviz-v2-common.js
@@ -1,0 +1,35 @@
+const PrimitiveTypes = [
+  'circles',
+  'images',
+  'points',
+  'polygons',
+  'polylines',
+  'stadiums',
+  'texts'
+];
+
+/**
+ * Primitives in v2 are a map with the 'type' as the key.
+ * This function validates the type and returns underlying array
+ *
+ */
+export function getPrimitiveData(primitiveObject) {
+  // v1
+  if (primitiveObject.type) {
+    return {type: primitiveObject.type, primitiveObject};
+  }
+
+  // v2
+  const keys = Object.keys(primitiveObject);
+
+  for (const type of keys) {
+    if (PrimitiveTypes.includes(type)) {
+      // Types in v2 are the plural form, but lookup in xviz-primitives-2.js
+      // uses singular, ie points -> point
+      const singularType = type.slice(0, -1);
+      return {type: singularType, primitives: primitiveObject[type]};
+    }
+  }
+
+  return null;
+}

--- a/modules/parser/src/styles/stylesheet.js
+++ b/modules/parser/src/styles/stylesheet.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console no-undef */
 import XvizStyleProperty from './xviz-style-property';
+import {get} from 'dotty';
 
 const SELECTOR_REGEX = /\S+/g;
 const OPERATOR_REGEX = /([=:~\*\^]+)/;
@@ -93,9 +94,12 @@ export default class Stylesheet {
     switch (operator) {
       case '=':
         return object => object && object[name] === value;
-      default:
-        return object =>
-          object && ((object.classes && object.classes.includes(name)) || object[name]);
+      default: {
+        return object => {
+          const classes = get(object, 'base.classes');
+          return object && ((classes && classes.includes(name)) || object[name]);
+        };
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
   "pre-commit": [
     "test"
   ],
-  "private": true
+  "private": true,
+  "dependencies": {
+    "protobufjs": "^6.8.8"
+  }
 }

--- a/test/modules/builder/glb-loader/glb-encode-parse.spec.js
+++ b/test/modules/builder/glb-loader/glb-encode-parse.spec.js
@@ -97,8 +97,8 @@ test('GLBLoader#encode-and-parse#full', t => {
   delete json.accessors;
 
   t.deepEqual(
-    json.updates[0].primitives['/tracklets'].primitives[0],
-    packJsonArrays(TEST_JSON.updates[0].primitives['/tracklets'].primitives[0]),
+    json.updates[0].primitives['/tracklets'].polygons[0],
+    packJsonArrays(TEST_JSON.updates[0].primitives['/tracklets'].polygons[0]),
     'Encoded and parsed GLB did not change data'
   );
 

--- a/test/modules/builder/glb-loader/glb-encoder-decoder.spec.js
+++ b/test/modules/builder/glb-loader/glb-encoder-decoder.spec.js
@@ -20,11 +20,11 @@ test('GLBLoader#encode-and-decode', t => {
 
   const glbFileBuffer = GLBEncoder.createGlbBuffer(json, arrayBuffer);
 
-  t.equal(glbFileBuffer.byteLength, 1272, 'should be equal');
+  t.equal(glbFileBuffer.byteLength, 1252, 'should be equal');
 
   const parsedData = GLBDecoder.parseGlbBuffer(glbFileBuffer);
 
-  t.equal(parsedData.binaryByteOffset, 1244);
+  t.equal(parsedData.binaryByteOffset, 1224);
   t.deepEqual(parsedData.json, json, 'JSON is equal');
 
   const buffers2 = unpackGLBBuffers(arrayBuffer, json);

--- a/test/modules/builder/glb-loader/test-data.json
+++ b/test/modules/builder/glb-loader/test-data.json
@@ -17,10 +17,11 @@
       },
       "primitives": {
         "/tracklets": {
-          "primitives": [
+          "polygons": [
               {
-                "type": "polygon",
-                "object_id": "f06700e3-e9a9-4d61-aeb5-fdd3dd1113d2",
+                "base": {
+                  "object_id": "f06700e3-e9a9-4d61-aeb5-fdd3dd1113d2"
+                },
                 "vertices": [
                   [
                     12.458602928956001,
@@ -50,7 +51,9 @@
                 ]
               },
               {
-                "object_id": "fac9bc35-b887-41da-9e4d-70e51243df34",
+                "base": {
+                  "object_id": "fac9bc35-b887-41da-9e4d-70e51243df34"
+                },
                 "vertices": [
                   [
                     5.218574751495583,
@@ -68,8 +71,7 @@
                     6.9959912573834435,
                     -2.011472543533862
                   ]
-                ],
-                "type": "polyline"
+                ]
               }
             ]
         }

--- a/test/modules/parser/parsers/parse-stream-data-message.spec.js
+++ b/test/modules/parser/parsers/parse-stream-data-message.spec.js
@@ -71,12 +71,15 @@ const TestTimesliceMessageV2 = {
       variables: null,
       primitives: {
         '/test/stream': {
-          primitives: [
+          points: [
             {
-              color: [255, 255, 255],
-              object_id: 1234,
+              base: {
+                object_id: '1234',
+                style: {
+                  fill_color: [255, 255, 255]
+                }
+              },
               radius: 0.01,
-              type: 'point',
               points: [[1000, 1000, 200]]
             }
           ]
@@ -242,12 +245,15 @@ tape('parseStreamLogData pointCloud timeslice', t => {
         },
         primitives: {
           '/test/stream': {
-            primitives: [
+            points: [
               {
-                color: [255, 255, 255],
-                object_id: 1234,
+                base: {
+                  object_id: 1234,
+                  style: {
+                    fill_color: [255, 255, 255]
+                  }
+                },
                 radius: 0.01,
-                type: 'point',
                 points: [[1000, 1000, 200]]
               }
             ]
@@ -287,12 +293,15 @@ tape('parseStreamLogData pointCloud timeslice TypedArray', t => {
         },
         primitives: {
           '/test/stream': {
-            primitives: [
+            points: [
               {
-                color: [255, 255, 255],
-                object_id: 1234,
+                base: {
+                  object_id: '1234',
+                  style: {
+                    fill_color: [255, 255, 255]
+                  }
+                },
                 radius: 0.01,
-                type: 'point',
                 points: new Float32Array([1000, 1000, 200])
               }
             ]
@@ -332,19 +341,25 @@ tape('parseStreamLogData pointCloud timeslice', t => {
         },
         primitives: {
           '/test/stream': {
-            primitives: [
+            points: [
               {
-                color: [255, 255, 255],
-                object_id: 1234,
+                object_id: '1234',
+                base: {
+                  style: {
+                    fill_color: [255, 255, 255]
+                  }
+                },
                 radius: 0.01,
-                type: 'point',
                 points: [[1000, 1000, 200]]
               },
               {
-                color: [255, 255, 255],
-                object_id: 1235,
+                object_id: '1235',
+                base: {
+                  style: {
+                    fill_color: [255, 255, 255]
+                  }
+                },
                 radius: 0.01,
-                type: 'point',
                 points: new Float32Array([1000, 1000, 200])
               }
             ]

--- a/test/modules/parser/styles/xviz-style-parser.spec.js
+++ b/test/modules/parser/styles/xviz-style-parser.spec.js
@@ -49,7 +49,7 @@ const BIKE = {type: 'bike'};
 const CAR = {type: 'car'};
 const TRACKED_CAR = {type: 'car', state: {tracked: true}};
 const TRACKED_BIKE = {type: 'bike', state: {tracked: true}};
-const FANCY_BUS = {type: 'bus', classes: ['fancy']};
+const FANCY_BUS = {type: 'bus', base: {classes: ['fancy']}};
 const GET_PROPERTY_TEST_CASES = [
   {
     propertyName: 'height',

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,6 +795,49 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2faspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2fbase64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2fcodegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2feventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2ffetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2ffloat/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2finquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2fpath/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2fpool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs%2futf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -7630,6 +7673,10 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -9029,6 +9076,24 @@ protobufjs@~6.8.8:
   version "6.8.8"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
   integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
+
+protobufjs@^6.8.8:
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
- update doc examples to match new 'base' primitive properties
- add util func to access primitives thur their top-level 'type' property
- parsed XVIZ needs context on object 'type', so while it is removed
  from objects parsing it will add it to the objects