### PR TITLE
Update changelog and docs for 0.2.0 and clean up code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add `XVIZWriter.writeFrameIndex` to write out a timestamp index file to be used
   by the Streetscape.gl XVIZ file server
 
+## [0.2.0] - 2018-XX-XXX
+### Changes
+Protobuf 3 schema compatibility updates.
+
+#### Breaking changes
+
+Protobuf 3 does not support inheritance so common fields had to be moved:
+
+ - Primitives moved `object_id`, `style_classes` and `inline_style` to a `base` sub-object
+ - Annotations moved `object_id` to a `base` sub-object
+ - Variables moved `object_id` to a `base` sub-object
+
+Due lack of polymorphism all mixed type arrays were removed:
+
+ - Changed `primitive_state` from one mixed `primitives` array to a array for each possible primitive type
+ - Changed `annotation_state` from one mixed `annotations` array to one `visuals` array
+ - Changed `future_instances` to hold an array of `primitive_state` objects instead of an arrays of mixed primitives
+ - Changed `treetable`'s node `column_value` to be an array of strings
+
+Protobuf 3 also lacks variants so we had to remove all usages:
+
+ - A new `values` type is defined that holds one array for each plain type: ints, double, strings, bools
+ - `timeseries_state` changed to holds parallel arrays of stream IDs and `values` type
+ - In `stream_metadta` the `DYNAMIC` transform type now specifies it's callback function name as the `transform_callback` field
+ - Changed `variable` to contain the `values` type instead of variant based `values` array
+
+Since everything is explicitly typed now we have:
+
+ - Removed type tags from annotations and primitives
+
+#### Non-Breaking changes
+
+ - Unstable Protobuf 3 IDL files are in `modules/schema/proto/v2`
+ - The 3x3 and 4x4 Matrix types can now be passed flat, because that that is how they are represented in protobuf
+ - `ui_panel_info` can now represent the declarative UI content as raw string because that is how protobuf will pass the JSON format of the declarative UI files
+
+
 ## [0.1.0] - 2018-10-24
 ### Changes
 - XVIZ specification finalization and tooling updates

--- a/docs/protocol-schema/session-protocol.md
+++ b/docs/protocol-schema/session-protocol.md
@@ -105,14 +105,23 @@ Metadata provides information about the structure of a stream. Ideally redundant
 removed from streams and put into metadata packets that are sent at the start of streaming or when a
 reconfiguration happens.
 
-| Name         | Type                              | Description                                                                                                                                                |
-| ------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `source`     | `string`                          | URL for where this stream comes from. Allowing you to fetch the data from S3 for example. An empty string means it comes through the standard XVIZ stream. |
-| `coordinate` | `optional<enum{ frames }>`        | Defaults to IDENTITY, defines the coordinate frame for the data in the stream                                                                              |
-| `transform`  | `string, 4x4`                     | String for IDENTITY, 4x4 matrix for `VEHICLE_RELATIVE`                                                                                                     |
-| `units`      | `string`                          | For variable and time series data this lets the user know what kind of data they are looking at.                                                           |
-| `value_map`  | `optional<enum{ stream values }>` | A list of all of the values that will be sent on the stream. The indexes of the values are used to translate them into numeric values for plotting.        |
-| `style_info` | `map<class_id, style>`            | Describes how the data should be rendered.                                                                                                                 |
+| Name                 | Type                              | Description                                                                                                                                                |
+| -------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source`             | `string`                          | URL for where this stream comes from. Allowing you to fetch the data from S3 for example. An empty string means it comes through the standard XVIZ stream. |
+| `coordinate`         | `optional<enum{ frames }>`        | Defaults to IDENTITY, defines the coordinate frame for the data in the stream                                                                              |
+| `transform`          | `4x4`                             | 4x4 matrix for `VEHICLE_RELATIVE`                                                                                                                          |
+| `transform_callback` | `string`                          | Callback function name for `DYNAMIC`                                                                                                                       |
+| `units`              | `string`                          | For variable and time series data this lets the user know what kind of data they are looking at.                                                           |
+| `value_map`          | `optional<enum{ stream values }>` | A list of all of the values that will be sent on the stream. The indexes of the values are used to translate them into numeric values for plotting.        |
+| `style_info`         | `map<class_id, style>`            | Describes how the data should be rendered.                                                                                                                 |
+
+Frames:
+
+- `IDENTITY` - data in meters, apply no transform to the data before display
+- `GEOGRAPHIC` - data in lat/lon/altitude
+- `VEHICLE_RELATIVE` - the data is relative to primary vehicle, with an optional additional
+  transform
+- `DYNAMIC` -
 
 ### Camera Info
 
@@ -133,10 +142,10 @@ Everything you need to display and deeply integrate video into a 3D application.
 
 UI configuration that comes with the data explaining how best to display it.
 
-| Name             | Type              | Description                                     |
-| ---------------- | ----------------- | ----------------------------------------------- |
-| `name`           | `string`          | Unique name for the panel                       |
-| `needed_streams` | `list<stream_id>` | What streams are needed to populate this panel. |
-| `config`         | `declarative_ui`  | Declarative UI panel configuration              |
+| Name             | Type                     | Description                                     |
+| ---------------- | ------------------------ | ----------------------------------------------- |
+| `name`           | `string`                 | Unique name for the panel                       |
+| `needed_streams` | `list<stream_id>`        | What streams are needed to populate this panel. |
+| `config`         | `string, declarative ui` | Declarative UI panel configuration              |
 
-**declarative_ui** - currently unspecified
+See [declarative ui specification](/docs/protocol-schema/declarative-ui.md) to learn more.

--- a/modules/schema/proto/v2/annotation.proto
+++ b/modules/schema/proto/v2/annotation.proto
@@ -1,3 +1,7 @@
+// --------------------------------------------------------
+// WARNING: XVIZ Protobuf files are unstable, do not use
+// --------------------------------------------------------
+
 syntax = "proto3";
 
 import "options.proto";

--- a/modules/schema/proto/v2/core.proto
+++ b/modules/schema/proto/v2/core.proto
@@ -1,3 +1,7 @@
+// --------------------------------------------------------
+// WARNING: XVIZ Protobuf files are unstable, do not use
+// --------------------------------------------------------
+
 syntax = "proto3";
 
 import "annotation.proto";
@@ -5,6 +9,7 @@ import "options.proto";
 import "primitives.proto";
 
 package xviz.v2.core;
+
 
 message StreamSet
 {
@@ -24,6 +29,7 @@ message StreamSet
     
     map<string, AnnotationState> annotations = 8;
 }
+
 
 message Pose
 {
@@ -79,9 +85,8 @@ message TimeSeriesState
     
     string object_id = 2;
 
-    // In the old JSON it's: [["stream", 1], ["stream", 2]]
-    // protobuf makes us do parallel lists
     repeated string streams = 3;
+    
     Values values = 4;
 }
 
@@ -130,7 +135,6 @@ message VariableBase
 
 message Values
 {
-    // TODO: create this
     option (xviz_json_schema) = "core/values";
 
     /// ONLY SET ONE OF THESE (protobuf does not all oneof

--- a/modules/schema/proto/v2/options.proto
+++ b/modules/schema/proto/v2/options.proto
@@ -1,3 +1,7 @@
+// --------------------------------------------------------
+// WARNING: XVIZ Protobuf files are unstable, do not use
+// --------------------------------------------------------
+
 syntax = "proto3";
 
 import "google/protobuf/descriptor.proto";

--- a/modules/schema/proto/v2/primitives.proto
+++ b/modules/schema/proto/v2/primitives.proto
@@ -1,3 +1,7 @@
+// --------------------------------------------------------
+// WARNING: XVIZ Protobuf files are unstable, do not use
+// --------------------------------------------------------
+
 syntax = "proto3";
 
 import "options.proto";

--- a/modules/schema/proto/v2/session.proto
+++ b/modules/schema/proto/v2/session.proto
@@ -1,3 +1,7 @@
+// --------------------------------------------------------
+// WARNING: XVIZ Protobuf files are unstable, do not use
+// --------------------------------------------------------
+
 syntax = "proto3";
 
 import "core.proto";

--- a/modules/schema/proto/v2/style.proto
+++ b/modules/schema/proto/v2/style.proto
@@ -1,3 +1,7 @@
+// --------------------------------------------------------
+// WARNING: XVIZ Protobuf files are unstable, do not use
+// --------------------------------------------------------
+
 syntax = "proto3";
 
 import "options.proto";
@@ -69,7 +73,7 @@ message StreamValue
 
     double angle = 6;
 
-        enum TextAnchor {
+    enum TextAnchor {
         // yeah enums are message scoped, thanks C++98
         text_anchor_not_set = 0;
         start = 1;

--- a/modules/schema/src/index.js
+++ b/modules/schema/src/index.js
@@ -9,4 +9,6 @@ export {
 
 export {default as XVIZValidator} from './validator';
 
-export {loadProtos} from './proto-validation';
+export {loadProtos, getXVIZProtoTypes, EXTENSION_PROPERTY} from './proto-validation';
+
+export {protoEnumsToInts, enumToIntField} from './proto-utils';

--- a/modules/schema/src/proto-utils.js
+++ b/modules/schema/src/proto-utils.js
@@ -1,0 +1,93 @@
+const PRIMITIVE_PROTO_TYPES = new Set([
+  'double',
+  'float',
+  'int32',
+  'int64',
+  'uint32',
+  'uint64',
+  'sint32',
+  'sint64',
+  'fixed32',
+  'fixed64',
+  'sfixed32',
+  'sfixed64',
+  'bool',
+  'string',
+  'bytes'
+]);
+
+export function protoEnumsToInts(protoType, jsonObject) {
+  const enumTypes = {};
+
+  protoType.nestedArray.map(function store(e) {
+    enumTypes[e.name] = e.values;
+    return e;
+  });
+
+  const fields = protoType.fields;
+
+  // Fix up fields
+  for (const fieldName in fields) {
+    if (fields.hasOwnProperty(fieldName)) {
+      const field = fields[fieldName];
+      const fieldValue = jsonObject[fieldName];
+
+      const values = enumTypes[field.type];
+
+      if (values !== undefined) {
+        enumToIntField(values, fieldName, jsonObject);
+      } else if (field.map) {
+        enumToIntMapField(field, jsonObject[fieldName]);
+      } else if (field.repeated) {
+        enumToIntRepeatedField(field, jsonObject[fieldName]);
+      } else if (typeof fieldValue === 'object') {
+        enumToIntMessageField(field, fieldValue);
+      }
+    }
+  }
+}
+
+export function enumToIntField(values, fieldName, jsonObject) {
+  const originalValue = jsonObject[fieldName];
+
+  if (originalValue !== undefined) {
+    const newValue = values[originalValue];
+
+    if (newValue === undefined) {
+      const msg = `Error: ${fieldName} not present on object`;
+      throw msg;
+    }
+
+    jsonObject[fieldName] = newValue;
+  }
+}
+
+function enumToIntMessageField(field, jsonObject) {
+  if (!PRIMITIVE_PROTO_TYPES.has(field.type) && jsonObject !== undefined) {
+    const subType = field.parent.lookupType(field.type);
+    protoEnumsToInts(subType, jsonObject);
+  }
+}
+
+function enumToIntMapField(field, jsonObject) {
+  if (!PRIMITIVE_PROTO_TYPES.has(field.type) && jsonObject !== undefined) {
+    const subType = field.parent.lookupType(field.type);
+
+    for (const propertyName in jsonObject) {
+      if (jsonObject.hasOwnProperty(propertyName)) {
+        const propertyValue = jsonObject[propertyName];
+        protoEnumsToInts(subType, propertyValue);
+      }
+    }
+  }
+}
+
+function enumToIntRepeatedField(field, jsonArray) {
+  if (!PRIMITIVE_PROTO_TYPES.has(field.type) && jsonArray !== undefined) {
+    const subType = field.parent.lookupType(field.type);
+
+    for (let i = 0; i < jsonArray.length; i++) {
+      protoEnumsToInts(subType, jsonArray[i]);
+    }
+  }
+}

--- a/modules/schema/src/proto-validation.js
+++ b/modules/schema/src/proto-validation.js
@@ -4,7 +4,9 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
-import {Root} from 'protobufjs';
+import {Root, Type} from 'protobufjs';
+
+export const EXTENSION_PROPERTY = '(xviz_json_schema)';
 
 export function loadProtos(protoDir) {
   // Gather up all the protobuf files
@@ -18,4 +20,28 @@ export function loadProtos(protoDir) {
   protoRoot.loadSync(protos, {keepCase: true});
 
   return protoRoot;
+}
+
+export function getXVIZProtoTypes(protoRoot) {
+  const protoTypes = [];
+
+  traverseTypes(protoRoot, function walk(type) {
+    if (type.options !== undefined) {
+      if (type.options[EXTENSION_PROPERTY] !== undefined) {
+        protoTypes.push(type);
+      }
+    }
+  });
+
+  return protoTypes;
+}
+
+function traverseTypes(current, fn) {
+  if (current instanceof Type)
+    // and/or protobuf.Enum, protobuf.Service etc.
+    fn(current);
+  if (current.nestedArray)
+    current.nestedArray.forEach(function eachType(nested) {
+      traverseTypes(nested, fn);
+    });
 }

--- a/test/modules/builder/builders/xviz-declare-ui-builder.spec.js
+++ b/test/modules/builder/builders/xviz-declare-ui-builder.spec.js
@@ -1,5 +1,8 @@
 import test from 'tape-catch';
 import {XVIZUIBuilder} from '@xviz/builder';
+import {XVIZValidator} from '@xviz/schema';
+
+const schemaValidator = new XVIZValidator();
 
 test('XvizBaseUIBuilder', t => {
   const builder = new XVIZUIBuilder({});
@@ -45,7 +48,14 @@ test('XvizBaseUIBuilder', t => {
   };
 
   const actual = builder.getUI();
+
   t.deepEqual(actual, expected, 'XVIZUIBuilder should match expectation');
+
+  for (const name in actual) {
+    if (actual.hasOwnProperty(name)) {
+      schemaValidator.validate('declarative-ui/panel', actual[name]);
+    }
+  }
 
   t.end();
 });

--- a/test/modules/builder/builders/xviz-metadata-builder.spec.js
+++ b/test/modules/builder/builders/xviz-metadata-builder.spec.js
@@ -229,6 +229,7 @@ test('XVIZMetadataBuilder#stylesheet', t => {
   };
 
   t.deepEqual(metadata, expected, 'XVIZMetadataBuilder build matches expected output');
+  schemaValidator.validate('session/metadata', metadata);
   t.end();
 });
 

--- a/test/modules/builder/builders/xviz-time-series-builder.spec.js
+++ b/test/modules/builder/builders/xviz-time-series-builder.spec.js
@@ -289,6 +289,7 @@ test('XVIZTimeSeriesBuilder#single entry id', t => {
   const data = builder.getData();
 
   t.deepEqual(data, expected, 'XVIZTimeSeriesBuilder single entry id matches expected output');
+  data.forEach(d => schemaValidator.validate('core/timeseries_state', d));
   t.end();
 });
 

--- a/test/modules/schema/index.js
+++ b/test/modules/schema/index.js
@@ -3,4 +3,5 @@ import './data.spec.js';
 import './examples.spec';
 import './file-validation.spec.js';
 import './proto-validation.spec.js';
+import './proto-utils.spec.js';
 import './validator.spec';

--- a/test/modules/schema/proto-utils.spec.js
+++ b/test/modules/schema/proto-utils.spec.js
@@ -1,0 +1,134 @@
+import {protoEnumsToInts, enumToIntField} from '@xviz/schema';
+import {parse} from 'protobufjs';
+
+import test from 'tape-catch';
+
+test('enumToIntEnumField#Good', t => {
+  const values = {zip: 0, zap: 1};
+
+  const goodObj = {
+    foo: 'zip'
+  };
+
+  const expObj = {
+    foo: 0
+  };
+
+  enumToIntField(values, 'foo', goodObj);
+  t.ok(JSON.stringify(goodObj) === JSON.stringify(expObj), 'Converted correct');
+
+  t.end();
+});
+
+test('enumToIntEnumField#Bad', t => {
+  const badObj = {
+    foo: 'doesnotexist'
+  };
+
+  t.throws(() => enumToIntField({a: 0}, 'foo', badObj), /Error/, 'Should throw error');
+
+  t.end();
+});
+
+const TEST_PROTO_IDL = `syntax = "proto3";
+message Test {
+  enum Enum {
+    zip   = 0;
+    zap   = 1;
+    sog   = 2;
+  }
+
+  Enum foo = 1;
+  uint32 other = 2;
+}
+
+message Nested {
+  Test sub = 1;
+
+  map<string, Test> mapped = 2;
+  map<string, uint32> primMap = 3;
+  map<string, Test> emptyMap = 4;
+
+  repeated Test list = 5;
+  repeated string primList = 6;
+  repeated Test emptyList = 7;
+}`;
+
+const TEST_PROTO_ROOT = parse(TEST_PROTO_IDL).root;
+
+const TEST_PROTO_TYPE = TEST_PROTO_ROOT.lookupType('Test');
+
+test('protoEnumsToInts#Simple', t => {
+  const goodObj = {
+    foo: 'zip',
+    other: 42
+  };
+
+  const expObj = {
+    foo: 0,
+    other: 42
+  };
+
+  protoEnumsToInts(TEST_PROTO_TYPE, goodObj);
+  t.ok(JSON.stringify(goodObj) === JSON.stringify(expObj), 'Converted enum');
+
+  t.end();
+});
+
+test('protoEnumsToInts#InvalidEnumType', t => {
+  const badObj = {
+    foo: 'doesnotexist',
+    other: 42
+  };
+
+  t.throws(() => protoEnumsToInts(TEST_PROTO_TYPE, badObj), /Error/, 'Should throw error');
+
+  t.end();
+});
+
+test('protoEnumsToInts#Nested', t => {
+  const nestedType = TEST_PROTO_ROOT.lookupType('Nested');
+
+  const nestedObj = {
+    sub: {
+      foo: 'sog'
+    },
+    mapped: {
+      foo: {
+        foo: 'zap',
+        other: 42
+      }
+    },
+    list: [
+      {
+        foo: 'zip'
+      }
+    ],
+    primMap: {a: 4, b: 2},
+    primList: ['a', 'b']
+  };
+
+  const expectedObj = {
+    sub: {
+      foo: 2
+    },
+    mapped: {
+      foo: {
+        foo: 1,
+        other: 42
+      }
+    },
+    list: [
+      {
+        foo: 0
+      }
+    ],
+    primMap: {a: 4, b: 2},
+    primList: ['a', 'b']
+  };
+
+  protoEnumsToInts(nestedType, nestedObj);
+  t.deepEqual(nestedObj, expectedObj, 'Converted nested and mapped enums');
+
+  t.end();
+});


### PR DESCRIPTION
The markdown protocol docs have been updated to reflect the changes
made for protobuf compatibility, and all the protobuf files have been
marked unstable.

To cleans things up a little bit the massive test for the proto
validation code has had some utility code factored out and some
function move out of the test.