### PR TITLE
Fix internal color schema JSON id

### DIFF
--- a/modules/schema/primitives/point.schema.json
+++ b/modules/schema/primitives/point.schema.json
@@ -18,7 +18,7 @@
       "oneOf": [
         {
           "items": {
-            "$ref": "https://xviz.org/schema/style/_color.schema.json"
+            "$ref": "https://xviz.org/schema/style/_color.json"
           }
         },
         {

--- a/modules/schema/style/_color.schema.json
+++ b/modules/schema/style/_color.schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://xviz.org/schema/style/_color.schema.json",
+  "id": "https://xviz.org/schema/style/_color.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Internal XVIZ RGBA color type",
   "oneOf": [

--- a/modules/schema/style/object_value.schema.json
+++ b/modules/schema/style/object_value.schema.json
@@ -5,10 +5,10 @@
   "type": "object",
   "properties": {
     "fill_color": {
-      "$ref": "https://xviz.org/schema/style/_color.schema.json"
+      "$ref": "https://xviz.org/schema/style/_color.json"
     },
     "stroke_color": {
-      "$ref": "https://xviz.org/schema/style/_color.schema.json"
+      "$ref": "https://xviz.org/schema/style/_color.json"
     },
     "stroke_width": {
       "type": "number"

--- a/modules/schema/style/stream_value.schema.json
+++ b/modules/schema/style/stream_value.schema.json
@@ -5,10 +5,10 @@
   "type": "object",
   "properties": {
       "fill_color": {
-        "$ref": "https://xviz.org/schema/style/_color.schema.json"
+        "$ref": "https://xviz.org/schema/style/_color.json"
       },
       "stroke_color": {
-        "$ref": "https://xviz.org/schema/style/_color.schema.json"
+        "$ref": "https://xviz.org/schema/style/_color.json"
       },
       "stroke_width": {
         "type": "number"


### PR DESCRIPTION
It was of the form `_color.schema.json` while our URIs are of the form
_color.json`.  This can cause problems with downstream tools that rely
on that pattern.