### PR TITLE
Add more checks and details around INCOMPLETE result from parsing v2

### DIFF
--- a/modules/parser/src/parsers/parse-timeslice-data-v2.js
+++ b/modules/parser/src/parsers/parse-timeslice-data-v2.js
@@ -20,6 +20,17 @@ export default function parseTimesliceData(data, convertPrimitive) {
     );
   }
 
+  if (!updates) {
+    return {type: LOG_STREAM_MESSAGE.INCOMPLETE, message: 'Missing required "updates" property'};
+  }
+
+  if (updates && updates.length === 0) {
+    return {
+      type: LOG_STREAM_MESSAGE.INCOMPLETE,
+      message: 'Property "updates" has length of 0, no data?'
+    };
+  }
+
   if (updates.length > 1) {
     throw new Error(
       `Only XVIZ first update of "snapshot" is currently supported. Current updates has "${
@@ -30,7 +41,7 @@ export default function parseTimesliceData(data, convertPrimitive) {
 
   const stateUpdates = updates;
 
-  let timestamp = data.timestamp;
+  let timestamp = null;
   if (!timestamp && stateUpdates) {
     timestamp = stateUpdates.reduce((t, stateUpdate) => {
       return Math.max(t, stateUpdate.timestamp);
@@ -39,7 +50,7 @@ export default function parseTimesliceData(data, convertPrimitive) {
 
   if (!timestamp) {
     // Incomplete stream message, just tag it accordingly so client can ignore it
-    return {type: LOG_STREAM_MESSAGE.INCOMPLETE};
+    return {type: LOG_STREAM_MESSAGE.INCOMPLETE, message: 'Missing timestamp in "updates"'};
   }
 
   const newStreams = {};

--- a/test/modules/parser/parsers/parse-stream-data-message.spec.js
+++ b/test/modules/parser/parsers/parse-stream-data-message.spec.js
@@ -5,11 +5,14 @@ import {
   parseStreamLogData,
   LOG_STREAM_MESSAGE
 } from '@xviz/parser';
+import {XVIZValidator} from '@xviz/schema';
 
 import tape from 'tape-catch';
 import TestMetadataMessage from 'test-data/sample-metadata-message';
 import TestMetadataMessageV1 from 'test-data/sample-metadata-message-v1';
 import TestFuturesMessageV1 from 'test-data/sample-frame-futures-v1';
+
+const schemaValidator = new XVIZValidator();
 
 // xviz data uses snake_case
 /* eslint-disable camelcase */
@@ -71,12 +74,12 @@ const TestTimesliceMessageV2 = {
       poses: {
         '/vehicle_pose': {
           timestamp: 1001.0,
-          mapOrigin: [11.2, 33.4, 55.6],
+          mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
           position: [1.1, 2.2, 3.3],
           orientation: [0.1, 0.2, 0.3]
         }
       },
-      variables: null,
+      variables: {},
       primitives: {
         '/test/stream': {
           points: [
@@ -87,7 +90,6 @@ const TestTimesliceMessageV2 = {
                   fill_color: [255, 255, 255]
                 }
               },
-              radius: 0.01,
               points: [[1000, 1000, 200]]
             }
           ]
@@ -215,6 +217,58 @@ tape('parseStreamLogData metadata with full log time only', t => {
   t.end();
 });
 
+tape('parseStreamLogData validate test data', t => {
+  schemaValidator.validate('session/state_update', TestTimesliceMessageV2);
+  t.end();
+});
+
+tape('parseStreamLogData validate result when missing updates', t => {
+  setXvizSettings({currentMajorVersion: 2});
+  setXvizSettings(defaultXvizSettings);
+
+  const metaMessage = parseStreamLogData({
+    update_type: 'snapshot'
+  });
+
+  t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Type after parse set to error');
+  t.ok(/Missing required/.test(metaMessage.message), 'Message details on what is missing');
+
+  t.end();
+});
+
+tape('parseStreamLogData validate result when updates is empty', t => {
+  setXvizSettings({currentMajorVersion: 2});
+  setXvizSettings(defaultXvizSettings);
+
+  const metaMessage = parseStreamLogData({
+    update_type: 'snapshot',
+    updates: []
+  });
+
+  t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Type after parse set to error');
+  t.ok(/"updates" has length of 0/.test(metaMessage.message), 'Message details length is 0');
+
+  t.end();
+});
+
+tape('parseStreamLogData validate result when missing timestamp in updates', t => {
+  setXvizSettings({currentMajorVersion: 2});
+  setXvizSettings(defaultXvizSettings);
+
+  const metaMessage = parseStreamLogData({
+    update_type: 'snapshot',
+    updates: [{}]
+  });
+
+  t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Type after parse set to error');
+  t.ok(
+    /Missing timestamp in "updates"/.test(metaMessage.message),
+    'Message details missing timestamp'
+  );
+
+  t.end();
+});
+
 tape('parseStreamLogData error', t => {
   setXvizSettings({currentMajorVersion: 2});
   setXvizSettings(defaultXvizSettings);
@@ -251,7 +305,7 @@ tape('parseStreamLogData timeslice INCOMPLETE', t => {
       {
         poses: {
           '/vehicle_pose': {
-            mapOrigin: [11.2, 33.4, 55.6]
+            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6}
           }
         }
       }
@@ -346,7 +400,7 @@ tape('parseStreamLogData pointCloud timeslice', t => {
         poses: {
           '/vehicle_pose': {
             timestamp: 1001.0,
-            mapOrigin: [11.2, 33.4, 55.6],
+            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
             position: [1.1, 2.2, 3.3],
             orientation: [0.1, 0.2, 0.3]
           }
@@ -361,7 +415,6 @@ tape('parseStreamLogData pointCloud timeslice', t => {
                     fill_color: [255, 255, 255]
                   }
                 },
-                radius: 0.01,
                 points: [[1000, 1000, 200]]
               }
             ]
@@ -395,7 +448,7 @@ tape('parseStreamLogData pointCloud timeslice TypedArray', t => {
         poses: {
           '/vehicle_pose': {
             timestamp: 1001.0,
-            mapOrigin: [11.2, 33.4, 55.6],
+            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
             position: [1.1, 2.2, 3.3],
             orientation: [0.1, 0.2, 0.3]
           }
@@ -410,7 +463,6 @@ tape('parseStreamLogData pointCloud timeslice TypedArray', t => {
                     fill_color: [255, 255, 255]
                   }
                 },
-                radius: 0.01,
                 points: new Float32Array([1000, 1000, 200])
               }
             ]
@@ -444,7 +496,7 @@ tape('parseStreamLogData pointCloud timeslice', t => {
         poses: {
           '/vehicle_pose': {
             timestamp: 1001.0,
-            mapOrigin: [11.2, 33.4, 55.6],
+            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
             position: [1.1, 2.2, 3.3],
             orientation: [0.1, 0.2, 0.3]
           }
@@ -459,7 +511,6 @@ tape('parseStreamLogData pointCloud timeslice', t => {
                     fill_color: [255, 255, 255]
                   }
                 },
-                radius: 0.01,
                 points: [[1000, 1000, 200]]
               },
               {
@@ -469,7 +520,6 @@ tape('parseStreamLogData pointCloud timeslice', t => {
                     fill_color: [255, 255, 255]
                   }
                 },
-                radius: 0.01,
                 points: new Float32Array([1000, 1000, 200])
               }
             ]


### PR DESCRIPTION
- Removed a reference to a top-level timestamp that is not in the spec
- Added schema validation to the parse v2 test data