### PR TITLE
Define and update TreeTable schema

### DIFF
--- a/docs/protocol-schema/core-protocol.md
+++ b/docs/protocol-schema/core-protocol.md
@@ -124,15 +124,16 @@ float, boolean
 This is a single cohesive set of streams which all happened at the same time and be associated with
 a single system frame. This is what an XVIZ extractor produces.
 
-| Name            | Type                               | Description                                                                                                                 |
-| --------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `timestamp`     | `timestamp`                        | The vehicle/log transmission_time associated with this data.                                                                |
-| `primitives`    | `map<stream_id, primitive_state>`  | Streams containing list of primitives.                                                                                      |
-| `poses`         | `map<stream_id, pose>`             | Related vehicle poses                                                                                                       |
-| `time_series`   | `list<time_series_state>`          |                                                                                                                             |
-| `future_states` | `map<stream_id, future_instances>` | Streams containing This represents a collection of primitives at different timestamps, for the current stream set timestamp |
-| `variables`     | `map<stream_id, variable_state>`   | Streams containing list of values.                                                                                          |
-| `annotations`   | `map<stream_id, annotation_state>` | Streams containing annotations                                                                                              |
+| Name            | Type                                 | Description                                                                                                                 |
+| --------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `timestamp`     | `timestamp`                          | The vehicle/log transmission_time associated with this data.                                                                |
+| `primitives`    | `map<stream_id, primitive_state>`    | Streams containing list of primitives.                                                                                      |
+| `ui_primitives` | `map<stream_id, ui_primitive_state>` | Streams containing list of UI specific primitives.                                                                          |
+| `poses`         | `map<stream_id, pose>`               | Related vehicle poses                                                                                                       |
+| `time_series`   | `list<time_series_state>`            |                                                                                                                             |
+| `future_states` | `map<stream_id, future_instances>`   | Streams containing This represents a collection of primitives at different timestamps, for the current stream set timestamp |
+| `variables`     | `map<stream_id, variable_state>`     | Streams containing list of values.                                                                                          |
+| `annotations`   | `map<stream_id, annotation_state>`   | Streams containing annotations                                                                                              |
 
 This is what a full stream set would look like populated with a basic example of each element:
 
@@ -182,6 +183,37 @@ streams, `stream_set` or future points in time, `future_instances` to applicable
             "points": [[1, 2, 3]]
         }
     ]
+}
+```
+
+## UI Primitive State
+
+This holds a lists of UI primitives XVIZ. It's used by higher level to map streams, `stream_set`.
+
+| Name        | Type        | Description                   |
+| ----------- | ----------- | ----------------------------- |
+| `treetable` | `treetable` | table/tree to display in a UI |
+
+```js
+{
+    "treetable": {
+        "columns": [
+            {
+                "display_text": "Age",
+                "type": "integer"
+            }
+        ],
+        "nodes": [
+            {
+                "id": 0
+            },
+            {
+                "id": 1,
+                "parent": 0,
+                "column_values": [10]
+            }
+        ]
+    }
 }
 ```
 

--- a/docs/protocol-schema/ui-primitives.md
+++ b/docs/protocol-schema/ui-primitives.md
@@ -33,35 +33,43 @@ TreeTable nodes act like nodes in a tree or rows in a table. Note that columns a
 have a value at every node. An example of this would be how many file browsers don’t list a size for
 folders.
 
-| Name            | Type                            | Description                                                     |
-| --------------- | ------------------------------- | --------------------------------------------------------------- |
-| `id`            | `treetable_node_id`             | The ID of this node within the TreeTable                        |
-| `parent`        | `treetable_node_id`             | The ID of the parent, essentially a pointer to parent           |
-| `column_values` | `list<optional<value_variant>>` | A list of the column values with index corresponding to column. |
+| Name            | Type                          | Description                                                                       |
+| --------------- | ----------------------------- | --------------------------------------------------------------------------------- |
+| `id`            | `treetable_node_id`           | The ID of this node within the TreeTable                                          |
+| `parent`        | `optional<treetable_node_id>` | The ID of the parent, essentially a pointer to parent, not present in root nodes. |
+| `column_values` | `list<string>`                | A list of the column values with index corresponding to column.                   |
 
-### Error Handling in TreeTables
+## Example
 
-When parsing TreeTable values into JSON representations there is a possibility that an unparsable
-value or a value with an incorrect data type is present. To prevent a single bad value from crashing
-the entire TreeTable conversion, these values will be represented as null and an error message will
-be included in a special errors field in the TreeTable’s JSON representation.
+Here is an example tree table with two columns "Age" and "Name".
 
-#### The Errors Field
-
-The errors field is used to send additional information about any errors that came up while
-converting the TreeTable from its server side representation into JSON.
-
-| Name     | Type                    | Description                                                         |
-| -------- | ----------------------- | ------------------------------------------------------------------- |
-| `errors` | `list<treetable_error>` | A list of errors with more detailed information about what happened |
-
-#### The TreeTable Error Type
-
-The TreeTable error type includes information about the location within the treetable where the
-error occurred along with a description of what error has occurred.
-
-| Name      | Type                  | Description                                |
-| --------- | --------------------- | ------------------------------------------ |
-| `message` | `string`              | Details of what error has occurred and why |
-| `column`  | `treetable_column_id` | The column with the error value            |
-| `node`    | `treetable_node_id`   | The node/row with the error value          |
+```javascript
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "integer",
+      "unit": "Years"
+    },
+    {
+      "display_text": "Name",
+      "type": "string"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0
+    },
+    {
+      "id": 1,
+      "parent": 0,
+      "column_values": ["10", "Jim"]
+    },
+    {
+      "id": 2,
+      "parent": 0,
+      "column_values": ["22", "Bob"]
+    }
+  ]
+}
+```

--- a/modules/schema/core/stream_set.schema.json
+++ b/modules/schema/core/stream_set.schema.json
@@ -25,6 +25,12 @@
         "$ref": "https://xviz.org/schema/core/primitive_state.json"
       }
     },
+    "ui_primitives": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "https://xviz.org/schema/core/ui_primitive_state.json"
+      }
+    },
     "time_series": {
       "type": "array",
       "items": {

--- a/modules/schema/core/ui_primitive_state.schema.json
+++ b/modules/schema/core/ui_primitive_state.schema.json
@@ -1,0 +1,12 @@
+{
+  "id": "https://xviz.org/schema/core/ui_primitive_state.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "XVIZ UI Primitive State",
+  "type": "object",
+  "properties": {
+    "treetable" : {
+      "$ref": "https://xviz.org/schema/ui-primitives/treetable.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/modules/schema/examples/core/stream_set/complete.json
+++ b/modules/schema/examples/core/stream_set/complete.json
@@ -1,5 +1,6 @@
 {
   "timestamp": 1001.3,
+
   "poses": {
     "/vehicle_pose": {
       "timestamp": 1001.3,
@@ -22,6 +23,7 @@
       "orientation": [1.5, 95.0, 24.5]
     }
   },
+
   "primitives": {
     "/object/points": {
       "points": [
@@ -109,6 +111,35 @@
       ]
     }
   },
+
+  "ui_primitives": {
+    "/ui/pred/objects": {
+      "treetable": {
+        "columns": [
+          {
+            "display_text": "Age",
+            "type": "integer",
+            "unit": "Years"
+          },
+          {
+            "display_text": "Name",
+            "type": "string"
+            }
+        ],
+        "nodes": [
+          {
+            "id": 0,
+            "column_values": ["10", "Jim"]
+          },
+          {
+            "id": 1,
+            "column_values": ["22", "Bob"]
+          }
+        ]
+      }
+    }
+  },
+
   "time_series": [
     {
       "timestamp": 12345.5,
@@ -139,6 +170,7 @@
       }
     }
   ],
+
   "future_instances": {
     "/prediction/points": {
       "timestamps": [1.0, 1.1, 1.2],
@@ -167,6 +199,7 @@
       ]
     }
   },
+
   "variables": {
     "/plan/time": {
       "variables": [
@@ -196,6 +229,7 @@
       ]
     }
   },
+
   "annotations": {
     "/object/highlights": {
       "visuals": [

--- a/modules/schema/examples/core/ui_primitive_state/treetable.json
+++ b/modules/schema/examples/core/ui_primitive_state/treetable.json
@@ -1,0 +1,25 @@
+{
+  "treetable": {
+    "columns": [
+      {
+        "display_text": "Age",
+        "type": "integer",
+        "unit": "Years"
+      },
+      {
+        "display_text": "Name",
+        "type": "string"
+      }
+    ],
+    "nodes": [
+      {
+        "id": 0,
+        "column_values": ["10", "Jim"]
+        },
+      {
+        "id": 1,
+        "column_values": ["22", "Bob"]
+      }
+    ]
+  }
+}

--- a/modules/schema/examples/ui-primitives/treetable/complete.json
+++ b/modules/schema/examples/ui-primitives/treetable/complete.json
@@ -1,0 +1,28 @@
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "integer",
+      "unit": "Years"
+    },
+    {
+      "display_text": "Name",
+      "type": "string"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0
+    },
+    {
+      "id": 1,
+      "parent": 0,
+      "column_values": ["10", "Jim"]
+    },
+    {
+      "id": 2,
+      "parent": 0,
+      "column_values": ["22", "Bob"]
+    }
+  ]
+}

--- a/modules/schema/examples/ui-primitives/treetable/flat.json
+++ b/modules/schema/examples/ui-primitives/treetable/flat.json
@@ -1,0 +1,23 @@
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "integer",
+      "unit": "Years"
+    },
+    {
+      "display_text": "Name",
+      "type": "string"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0,
+      "column_values": ["10", "Jim"]
+    },
+    {
+      "id": 1,
+      "column_values": ["22", "Bob"]
+    }
+  ]
+}

--- a/modules/schema/examples/ui-primitives/treetable/plaintable.json
+++ b/modules/schema/examples/ui-primitives/treetable/plaintable.json
@@ -1,0 +1,23 @@
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "integer",
+      "unit": "Years"
+    },
+    {
+      "display_text": "Name",
+      "type": "string"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0,
+      "column_values": ["10", "Jim"]
+    },
+    {
+      "id": 1,
+      "column_values": ["22", "Bob"]
+    }
+  ]
+}

--- a/modules/schema/invalid/ui-primitives/treetable/bad_column_data.json
+++ b/modules/schema/invalid/ui-primitives/treetable/bad_column_data.json
@@ -1,0 +1,18 @@
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "integer"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0
+    },
+    {
+      "id": 1,
+      "parent": 0,
+      "column_values": [10]
+    }
+  ]
+}

--- a/modules/schema/invalid/ui-primitives/treetable/bad_column_type.json
+++ b/modules/schema/invalid/ui-primitives/treetable/bad_column_type.json
@@ -1,0 +1,18 @@
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "foobar"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0
+    },
+    {
+      "id": 1,
+      "parent": 0,
+      "column_values": ["10"]
+    }
+  ]
+}

--- a/modules/schema/invalid/ui-primitives/treetable/missing_column_type.json
+++ b/modules/schema/invalid/ui-primitives/treetable/missing_column_type.json
@@ -1,0 +1,17 @@
+{
+  "columns": [
+    {
+      "display_text": "Age"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0
+    },
+    {
+      "id": 1,
+      "parent": 0,
+      "column_values": ["10"]
+    }
+  ]
+}

--- a/modules/schema/invalid/ui-primitives/treetable/missing_node_id.json
+++ b/modules/schema/invalid/ui-primitives/treetable/missing_node_id.json
@@ -1,0 +1,17 @@
+{
+  "columns": [
+    {
+      "display_text": "Age",
+      "type": "integer"
+    }
+  ],
+  "nodes": [
+    {
+      "id": 0
+    },
+    {
+      "parent": 0,
+      "column_values": ["10"]
+    }
+  ]
+}

--- a/modules/schema/proto/v2/core.proto
+++ b/modules/schema/proto/v2/core.proto
@@ -7,6 +7,7 @@ syntax = "proto3";
 import "annotation.proto";
 import "options.proto";
 import "primitives.proto";
+import "uiprimitives.proto";
 
 package xviz.v2.core;
 
@@ -14,7 +15,7 @@ package xviz.v2.core;
 message StreamSet
 {
     option (xviz_json_schema) = "core/stream_set";
-    
+
     double timestamp = 1;
 
     map<string, Pose> poses = 2;
@@ -24,24 +25,26 @@ message StreamSet
     repeated TimeSeriesState time_series = 4;
 
     map<string, FutureInstances> future_instances = 6;
-    
+
     map<string, VariableState> variables = 7;
-    
+
     map<string, AnnotationState> annotations = 8;
+
+    map<string, UIPrimitiveState> ui_primitives = 9;
 }
 
 
 message Pose
 {
     option (xviz_json_schema) = "core/pose";
-    
+
     double timestamp = 1;
 
     MapOrigin mapOrigin = 2;
 
     /// 3 element x, y, z
     repeated double position = 3;
-    
+
     // 4 element quaternion
     repeated double orientation = 4;
 }
@@ -50,9 +53,9 @@ message Pose
 message MapOrigin
 {
     double longitude = 1;
-    
+
     double latitude = 2;
-    
+
     double altitude = 3;
 }
 
@@ -60,33 +63,41 @@ message MapOrigin
 message PrimitiveState
 {
     option (xviz_json_schema) = "core/primitive_state";
-    
+
     repeated primitive.Polygon polygons = 1;
-    
+
     repeated primitive.Polyline polylines = 2;
 
     repeated primitive.Text texts = 3;
-    
+
     repeated primitive.Circle circles = 4;
 
     repeated primitive.Point points = 5;
-    
+
     repeated primitive.Stadium stadiums = 6;
-    
+
     repeated primitive.Image images = 7;
+}
+
+
+message UIPrimitiveState
+{
+    option (xviz_json_schema) = "core/ui_primitive_state";
+
+    uiprimitive.TreeTable treetable = 1;
 }
 
 
 message TimeSeriesState
 {
     option (xviz_json_schema) = "core/timeseries_state";
-    
+
     double timestamp = 1;
-    
+
     string object_id = 2;
 
     repeated string streams = 3;
-    
+
     Values values = 4;
 }
 
@@ -94,9 +105,9 @@ message TimeSeriesState
 message FutureInstances
 {
     option (xviz_json_schema) = "core/future_instances";
-    
+
     repeated double timestamps = 1;
-    
+
     repeated PrimitiveState primitives = 2;
 }
 
@@ -104,7 +115,7 @@ message FutureInstances
 message VariableState
 {
     option (xviz_json_schema) = "core/variable_state";
-    
+
     repeated Variable variables = 1;
 }
 
@@ -112,7 +123,7 @@ message VariableState
 message AnnotationState
 {
     option (xviz_json_schema) = "core/annotation_state";
-    
+
     repeated annotation.Visual visuals = 1;
 }
 
@@ -120,7 +131,7 @@ message AnnotationState
 message Variable
 {
     option (xviz_json_schema) = "core/variable";
-    
+
     VariableBase base = 1;
 
     Values values = 2;

--- a/modules/schema/proto/v2/uiprimitives.proto
+++ b/modules/schema/proto/v2/uiprimitives.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+import "options.proto";
+
+package xviz.v2.uiprimitive;
+
+message TreeTable
+{
+    option (xviz_json_schema) = "ui-primitives/treetable";
+
+    repeated TreeTableColumn columns = 1;
+
+    repeated TreeTableNode nodes = 2;
+}
+
+message TreeTableColumn
+{
+    string display_text = 1;
+
+    enum ColumnType {
+        column_type_not_set = 0;
+        integer = 1;
+        double = 2;
+        string = 3;
+        boolean = 4;
+    }
+
+    ColumnType type = 2;
+
+    string unit = 3;
+}
+
+message TreeTableNode
+{
+    int32 id = 1;
+
+    int32 parent = 2;
+
+    repeated string column_values = 3;
+}

--- a/modules/schema/src/data.js
+++ b/modules/schema/src/data.js
@@ -10,6 +10,7 @@ import corePrimitiveBaseSchemaJson from '../core/primitive_base.schema.json';
 import corePrimitiveStateSchemaJson from '../core/primitive_state.schema.json';
 import coreStreamSetSchemaJson from '../core/stream_set.schema.json';
 import coreTimeseriesStateSchemaJson from '../core/timeseries_state.schema.json';
+import coreUiPrimitiveStateSchemaJson from '../core/ui_primitive_state.schema.json';
 import coreValueSchemaJson from '../core/value.schema.json';
 import coreValuesSchemaJson from '../core/values.schema.json';
 import coreVariableSchemaJson from '../core/variable.schema.json';
@@ -43,6 +44,7 @@ import styleClassSchemaJson from '../style/class.schema.json';
 import styleColorSchemaJson from '../style/_color.schema.json';
 import styleObjectValueSchemaJson from '../style/object_value.schema.json';
 import styleStreamValueSchemaJson from '../style/stream_value.schema.json';
+import uiPrimitivesTreetableSchemaJson from '../ui-primitives/treetable.schema.json';
 
 export const SCHEMA_DATA = {
   'core/annotation_base.schema.json': coreAnnotationBaseSchemaJson,
@@ -55,6 +57,7 @@ export const SCHEMA_DATA = {
   'core/primitive_state.schema.json': corePrimitiveStateSchemaJson,
   'core/stream_set.schema.json': coreStreamSetSchemaJson,
   'core/timeseries_state.schema.json': coreTimeseriesStateSchemaJson,
+  'core/ui_primitive_state.schema.json': coreUiPrimitiveStateSchemaJson,
   'core/value.schema.json': coreValueSchemaJson,
   'core/values.schema.json': coreValuesSchemaJson,
   'core/variable.schema.json': coreVariableSchemaJson,
@@ -87,5 +90,6 @@ export const SCHEMA_DATA = {
   'style/class.schema.json': styleClassSchemaJson,
   'style/_color.schema.json': styleColorSchemaJson,
   'style/object_value.schema.json': styleObjectValueSchemaJson,
-  'style/stream_value.schema.json': styleStreamValueSchemaJson
+  'style/stream_value.schema.json': styleStreamValueSchemaJson,
+  'ui-primitives/treetable.schema.json': uiPrimitivesTreetableSchemaJson
 };

--- a/modules/schema/ui-primitives/treetable.schema.json
+++ b/modules/schema/ui-primitives/treetable.schema.json
@@ -1,0 +1,64 @@
+{
+  "id": "https://xviz.org/schema/ui-primitives/treetable.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "XVIZ Treetable",
+  "type": "object",
+  "properties": {
+    "columns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "display_text": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "integer",
+              "double",
+              "string",
+              "boolean"
+            ]
+          },
+          "unit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "display_text",
+          "type"
+        ],
+        "additionalProperties": false
+      },
+      "additionalItems": false
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "parent": {
+          "type": "integer"
+          },
+          "column_values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "additionalItems": false
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      },
+      "additionalItems": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
We have translated the documented schema into a formal JSON and
protobuf schema with a set of invalid and valid examples.

The schema has changed to having all column values encoded as strings
for now.  In the future when we can figure out a more efficient
protobuf compatible encoding we'll make a backwards compatible switch
to that.