### PR TITLE
Discard image data after parsing

### DIFF
--- a/modules/parser/src/parsers/xviz-primitives-v2.js
+++ b/modules/parser/src/parsers/xviz-primitives-v2.js
@@ -67,7 +67,8 @@ export default {
     validate: (primitive, streamName, time) => primitive.data,
     normalize: primitive => {
       let imageData = primitive.data;
-      if (typeof primitive.data === 'string') {
+      delete primitive.data;
+      if (typeof imageData === 'string') {
         imageData = base64js.toByteArray(imageData);
       }
       // format is not part of v2 spec

--- a/modules/parser/src/workers/stream-data.worker.js
+++ b/modules/parser/src/workers/stream-data.worker.js
@@ -1,33 +1,4 @@
 /* global self */
-import {setXVIZConfig, setXVIZSettings} from '../config/xviz-config';
-import {parseStreamDataMessage} from '../parsers/parse-stream-data-message';
-import {preSerialize} from '../parsers/serialize';
-function onResult(message) {
-  const transfers = [];
-  const {channels} = message;
-  if (channels) {
-    for (const streamName in channels) {
-      const {pointCloud} = channels[streamName];
-      if (pointCloud) {
-        transfers.push(
-          pointCloud.ids.buffer,
-          pointCloud.colors.buffer,
-          pointCloud.positions.buffer
-        );
-      }
-    }
-  }
-  message = preSerialize(message);
-  self.postMessage(message, transfers);
-}
-function onError(error) {
-  throw error;
-}
-self.onmessage = e => {
-  if (e.data.xvizConfig) {
-    setXVIZConfig(e.data.xvizConfig);
-    setXVIZSettings(e.data.xvizSettings);
-  } else {
-    parseStreamDataMessage(e.data, onResult, onError);
-  }
-};
+import getStreamDataWorker from './stream-data-worker';
+
+getStreamDataWorker({})(self);


### PR DESCRIPTION
We do not want to serialize and send the original image data between threads.