### PR TITLE
Add explicit XVIZ envelope support

### DIFF
--- a/docs/protocol-formats/json-protocol.md
+++ b/docs/protocol-formats/json-protocol.md
@@ -1,44 +1,79 @@
 # XVIZ JSON Protocol Format
 
 The JSON XVIZ format is a straight forward mapping of the XVIZ protocol schema contained within an
-envelope that denotes what type the object is.
+optional envelope that denotes what type the object is.
 
 ## Data Type Conversion
 
 The table below provides guidelines on how to convert the types specified in this document into
 JSON.
 
-| Type                                           | JSON Representation                |
-| ---------------------------------------------- | ---------------------------------- |
-| All Core Types (primitive, annotation, styles) | Object `{}`                        |
-| `list<>`                                       | Array []                           |
-| `map<>`                                        | Object `{"key": "value"}`          |
-| `optional<T>`                                  | `null` if not present, otherwise T |
+| Type                                           | JSON Representation                          |
+| ---------------------------------------------- | -------------------------------------------- |
+| All Core Types (primitive, annotation, styles) | Object `{}`                                  |
+| `list<>`                                       | Array []                                     |
+| `map<>`                                        | Object `{"key": "value"}`                    |
+| `optional<T>`                                  | `null` or absent if not present, otherwise T |
 
-## Data Envelope
+## WebSocket Data Envelope
 
-All XVIZ messages are enveloped with additional metadata about how to interpret them.
+This bundles the XVIZ messages in additional layer, allowing you to tell what type the message is,
+as well pass application specific messages on the same WebSocket connection as XVIZ data.
 
-The possible message types are captured in the message_types enum. Supported types are:
+The fields of the message
+
+| Name   | Type     | Description                          |
+| ------ | -------- | ------------------------------------ |
+| `type` | `string` | `namespace/type`                     |
+| `data` | `Object` | The actual message XVIZ or otherwise |
+
+Known namespaces:
+
+- `xviz`
+
+The valid XVIZ message types are:
 
 - `session_start` - Sent from the client upon connection
-- `session_reconfigure` - Sent from the client upon reconfiguration
 - `session_metadata` - Sent from the server upon connection or reconfiguration
 - `state_update` - Sent for messages containing primitives and variables
 
-| Name   | Type           | Description                   |
-| ------ | -------------- | ----------------------------- |
-| `type` | `message_type` | Explicit type of this message |
-| `data` | `message`      | The actual message itself     |
+### Examples
 
-A JSON example of this envelope for a state update message is
+The start message sent from the server to the client:
 
 ```
 {
-    "type": "state_update",
+    "type": "xviz/session_start",
+    "data": {
+        "version": "2.0.0",
+        "session_type": "live",
+        "message_format": "json"
+    }
+}
+```
+
+The metadata message, the first message sent from the server to the client:
+
+```
+{
+    "type": "xviz/session_metadata",
+    "data": {
+        "version": "2.0.0",
+        ...
+    }
+}
+```
+
+A state update message sent from the server to the client:
+
+```
+{
+    "type": "xviz/state_update",
     "data": {
         "update_type": "snapshot",
-        "updates": ...
+        "updates": [
+            ...
+        ]
     }
 }
 ```

--- a/modules/parser/src/index.js
+++ b/modules/parser/src/index.js
@@ -29,7 +29,12 @@ export {parseLogMetadata} from './parsers/parse-log-metadata';
 export {parseVehiclePose} from './parsers/parse-vehicle-pose';
 export {parseEtlStream} from './parsers/parse-etl-stream';
 export {parseStreamMessage, initializeWorkers} from './parsers/parse-stream-message';
-export {parseStreamDataMessage, parseStreamLogData} from './parsers/parse-stream-data-message';
+export {
+  parseStreamDataMessage,
+  parseStreamLogData,
+  isEnvelope,
+  unpackEnvelope
+} from './parsers/parse-stream-data-message';
 export {parseStreamVideoMessage} from './parsers/parse-stream-video-message';
 
 export {default as lidarPointCloudWorker} from './workers/lidar-point-cloud-worker';

--- a/modules/parser/src/parsers/parse-stream-data-message.js
+++ b/modules/parser/src/parsers/parse-stream-data-message.js
@@ -39,11 +39,27 @@ function decode(data, recursive) {
   return data;
 }
 
+// Parse apart the namespace and type for the enveloped data
+export function unpackEnvelope(data) {
+  const parts = data.type.split('/');
+  return {
+    namespace: parts[0],
+    type: parts.slice(1).join('/'),
+    data: data.data
+  };
+}
+
+// Sniff out whether the JSON data provided is in the XVIZ envelope format
+export function isEnvelope(data) {
+  return data.type && data.data;
+}
+
 // Post processes a stream message to make it easy to use for JavaScript applications
 export function parseStreamDataMessage(message, onResult, onError, opts) {
   // TODO(twojtasz): better message dispatching
   // here, not all arraybuffer may be image (packed point cloud)
-  if (message instanceof Blob) {
+  // TODO(jlisee): Node.js support for blobs for better unit testing
+  if (typeof Blob !== 'undefined' && message instanceof Blob) {
     parseStreamVideoMessage(message, onResult, onError);
     return;
   }
@@ -55,8 +71,21 @@ export function parseStreamDataMessage(message, onResult, onError, opts) {
     } else {
       data = decode(message, true);
     }
-    const result = parseStreamLogData(data, opts);
-    onResult(result);
+
+    let parseData = true;
+    if (isEnvelope(data)) {
+      const unpacked = unpackEnvelope(data);
+      if (unpacked.namespace === 'xviz') {
+        data = unpacked.data;
+      } else {
+        parseData = false;
+      }
+    }
+
+    if (parseData) {
+      const result = parseStreamLogData(data, opts);
+      onResult(result);
+    }
   } catch (error) {
     onError(error);
   }

--- a/modules/parser/src/parsers/parse-timeslice-data-v2.js
+++ b/modules/parser/src/parsers/parse-timeslice-data-v2.js
@@ -12,7 +12,7 @@ import {
 
 /* eslint-disable camelcase */
 
-export default function parseTimesliceData(data, convertPrimitive) {
+export default function parseStreamSet(data, convertPrimitive) {
   const {update_type, updates} = data;
 
   if (update_type !== 'snapshot') {
@@ -40,11 +40,11 @@ export default function parseTimesliceData(data, convertPrimitive) {
     );
   }
 
-  const stateUpdates = updates;
+  const streamSets = updates;
 
   let timestamp = null;
-  if (!timestamp && stateUpdates) {
-    timestamp = stateUpdates.reduce((t, stateUpdate) => {
+  if (!timestamp && streamSets) {
+    timestamp = streamSets.reduce((t, stateUpdate) => {
       return Math.max(t, stateUpdate.timestamp);
     }, 0);
   }
@@ -62,8 +62,8 @@ export default function parseTimesliceData(data, convertPrimitive) {
     // TODO/Xintong validate primary vehicle pose in each update?
   };
 
-  if (stateUpdates) {
-    const xvizStreams = parseStateUpdates(stateUpdates, timestamp, convertPrimitive);
+  if (streamSets) {
+    const xvizStreams = parseStreamSets(streamSets, timestamp, convertPrimitive);
     Object.assign(newStreams, xvizStreams);
   }
 
@@ -71,7 +71,7 @@ export default function parseTimesliceData(data, convertPrimitive) {
 }
 
 /* eslint-disable max-statements */
-function parseStateUpdates(stateUpdates, timestamp, convertPrimitive) {
+function parseStreamSets(streamSets, timestamp, convertPrimitive) {
   const {STREAM_BLACKLIST} = getXVIZConfig();
 
   const newStreams = {};
@@ -82,16 +82,16 @@ function parseStateUpdates(stateUpdates, timestamp, convertPrimitive) {
   const futures = {};
   const uiPrimitives = {};
 
-  for (const stateUpdate of stateUpdates) {
-    Object.assign(poses, stateUpdate.poses);
-    Object.assign(primitives, stateUpdate.primitives);
-    Object.assign(variables, stateUpdate.variables);
-    Object.assign(futures, stateUpdate.future_instances);
-    Object.assign(uiPrimitives, stateUpdate.ui_primitives);
+  for (const streamSet of streamSets) {
+    Object.assign(poses, streamSet.poses);
+    Object.assign(primitives, streamSet.primitives);
+    Object.assign(variables, streamSet.variables);
+    Object.assign(futures, streamSet.future_instances);
+    Object.assign(uiPrimitives, streamSet.ui_primitives);
 
-    if (stateUpdate.time_series) {
+    if (streamSet.time_series) {
       if (timeSeries) {
-        timeSeries.push(...stateUpdate.time_series);
+        timeSeries.push(...streamSet.time_series);
       }
     }
   }

--- a/test/modules/parser/parsers/parse-stream-data-message.spec.js
+++ b/test/modules/parser/parsers/parse-stream-data-message.spec.js
@@ -2,6 +2,9 @@ import {
   setXVIZConfig,
   getXVIZSettings,
   setXVIZSettings,
+  parseStreamDataMessage,
+  isEnvelope,
+  unpackEnvelope,
   parseStreamLogData,
   LOG_STREAM_MESSAGE
 } from '@xviz/parser';
@@ -98,6 +101,43 @@ const TestTimesliceMessageV2 = {
     }
   ]
 };
+
+tape('isEnvelope', t => {
+  t.ok(isEnvelope({type: 'foo', data: {a: 42}}), 'Detected XVIZ envelope');
+
+  t.notok(isEnvelope(TestTimesliceMessageV1), 'V1 data not in envelope');
+
+  t.notok(isEnvelope(TestTimesliceMessageV2), 'V2 data not in envelope');
+
+  t.end();
+});
+
+tape('unpackEnvelope name parsing', t => {
+  const notype = unpackEnvelope({type: 'foo', data: {a: 42}});
+  t.equals('foo', notype.namespace);
+  t.equals('', notype.type);
+
+  const empty = unpackEnvelope({type: '', data: {a: 42}});
+  t.equals('', empty.namespace);
+  t.equals('', empty.type);
+
+  t.end();
+});
+
+tape('unpackEnvelope xviz', t => {
+  const enveloped = {
+    type: 'xviz/state_update',
+    data: {a: 42}
+  };
+  const expected = {
+    namespace: 'xviz',
+    type: 'state_update',
+    data: enveloped.data
+  };
+  t.deepEquals(expected, unpackEnvelope(enveloped));
+
+  t.end();
+});
 
 // TODO: blacklisted streams in xviz common
 tape('parseStreamLogData metadata', t => {
@@ -599,6 +639,98 @@ tape('parseStreamLogData futures timeslice v1', t => {
 
   const lookAheads = slice.streams['/test/polygon'].lookAheads;
   t.equals(lookAheads.length, 2, 'Has 2 primitive sets in lookAheads');
+
+  t.end();
+});
+
+tape('parseStreamDataMessage', t => {
+  setXVIZSettings({currentMajorVersion: 2});
+  setXVIZSettings(defaultXVIZSettings);
+
+  let result;
+  let error;
+  const opts = {};
+  parseStreamDataMessage(
+    {...TestTimesliceMessageV2},
+    newResult => {
+      result = newResult;
+    },
+    newError => {
+      error = newError;
+    },
+    opts
+  );
+
+  t.equals(undefined, error, 'No errors received while parsing');
+  t.equals(result.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Message type set for timeslice');
+  t.equals(
+    result.timestamp,
+    TestTimesliceMessageV2.updates[0].poses['/vehicle_pose'].timestamp,
+    'Message timestamp set from vehicle_pose'
+  );
+
+  t.end();
+});
+
+tape('parseStreamDataMessage enveloped', t => {
+  setXVIZSettings({currentMajorVersion: 2});
+  setXVIZSettings(defaultXVIZSettings);
+
+  const enveloped = {
+    type: 'xviz/state_update',
+    data: {...TestTimesliceMessageV2}
+  };
+
+  let result;
+  let error;
+  const opts = {};
+  parseStreamDataMessage(
+    enveloped,
+    newResult => {
+      result = newResult;
+    },
+    newError => {
+      error = newError;
+    },
+    opts
+  );
+
+  t.equals(undefined, error, 'No errors received while parsing');
+  t.equals(result.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Message type set for timeslice');
+  t.equals(
+    result.timestamp,
+    TestTimesliceMessageV2.updates[0].poses['/vehicle_pose'].timestamp,
+    'Message timestamp set from vehicle_pose'
+  );
+
+  t.end();
+});
+
+tape('parseStreamDataMessage enveloped not xviz', t => {
+  setXVIZSettings({currentMajorVersion: 2});
+  setXVIZSettings(defaultXVIZSettings);
+
+  const enveloped = {
+    type: 'bar/foo',
+    data: {a: 42}
+  };
+
+  let result;
+  let error;
+  const opts = {};
+  parseStreamDataMessage(
+    enveloped,
+    newResult => {
+      result = newResult;
+    },
+    newError => {
+      error = newError;
+    },
+    opts
+  );
+
+  t.equals(undefined, error, 'No errors received while parsing');
+  t.equals(undefined, result, 'No data parsed, unknown type');
 
   t.end();
 });


### PR DESCRIPTION
This extra layer lets you use XVIZ messages on a WebSocket with
application specification messages.  It also provides the actual type
of the underlying message which is important for understanding how to
parse and handle the message.

This changes includes both documentation updates as well as backwards
compatible update to parser itself.  No generation side code has been
modified yet.

This can also facilitate further cleanups of downstream data paths,
but that has been left for future commits.