### PR TITLE
Lint all markdown files with prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,66 +1,77 @@
 # Change Log
 
-All notable changes to XVIZ will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
+All notable changes to XVIZ will be documented in this file. This project adheres to
+[Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
-- Add `XVIZWriter.writeFrameIndex` to write out a timestamp index file to be used
-  by the Streetscape.gl XVIZ file server
+
+- Add `XVIZWriter.writeFrameIndex` to write out a timestamp index file to be used by the
+  Streetscape.gl XVIZ file server
 
 ## [0.2.0] - 2018-XX-XXX
+
 ### Changes
+
 Protobuf 3 schema compatibility updates.
 
 #### Breaking changes
 
 Protobuf 3 does not support inheritance so common fields had to be moved:
 
- - Primitives moved `object_id`, `style_classes` and `inline_style` to a `base` sub-object
- - Annotations moved `object_id` to a `base` sub-object
- - Variables moved `object_id` to a `base` sub-object
+- Primitives moved `object_id`, `style_classes` and `inline_style` to a `base` sub-object
+- Annotations moved `object_id` to a `base` sub-object
+- Variables moved `object_id` to a `base` sub-object
 
 Due lack of polymorphism all mixed type arrays were removed:
 
- - Changed `primitive_state` from one mixed `primitives` array to a array for each possible primitive type
- - Changed `annotation_state` from one mixed `annotations` array to one `visuals` array
- - Changed `future_instances` to hold an array of `primitive_state` objects instead of an arrays of mixed primitives
- - Changed `treetable`'s node `column_value` to be an array of strings
+- Changed `primitive_state` from one mixed `primitives` array to a array for each possible primitive
+  type
+- Changed `annotation_state` from one mixed `annotations` array to one `visuals` array
+- Changed `future_instances` to hold an array of `primitive_state` objects instead of an arrays of
+  mixed primitives
+- Changed `treetable`'s node `column_value` to be an array of strings
 
 Protobuf 3 also lacks variants so we had to remove all usages:
 
- - A new `values` type is defined that holds one array for each plain type: ints, double, strings, bools
- - `timeseries_state` changed to holds parallel arrays of stream IDs and `values` type
- - In `stream_metadta` the `DYNAMIC` transform type now specifies it's callback function name as the `transform_callback` field
- - Changed `variable` to contain the `values` type instead of variant based `values` array
+- A new `values` type is defined that holds one array for each plain type: ints, double, strings,
+  bools
+- `timeseries_state` changed to holds parallel arrays of stream IDs and `values` type
+- In `stream_metadta` the `DYNAMIC` transform type now specifies it's callback function name as the
+  `transform_callback` field
+- Changed `variable` to contain the `values` type instead of variant based `values` array
 
 Since everything is explicitly typed now we have:
 
- - Removed type tags from annotations and primitives
+- Removed type tags from annotations and primitives
 
 `@xviz/parser` exports:
 
 - Renaming:
-  + `setXvizConfig` -> `setXVIZConfig`
-  + `getXvizConfig` -> `getXVIZConfig`
-  + `setXvizSettings` -> `setXVIZSettings`
-  + `getXvizSettings` -> `getXVIZSettings`
-  + `XvizStreamBuffer` -> `XVIZStreamBuffer`
-  + `XvizStyleParser` -> `XVIZStyleParser`
-  + `XvizObject` -> `XVIZObject`
-  + `XvizObjectCollection` -> `XVIZObjectCollection`
+  - `setXvizConfig` -> `setXVIZConfig`
+  - `getXvizConfig` -> `getXVIZConfig`
+  - `setXvizSettings` -> `setXVIZSettings`
+  - `getXvizSettings` -> `getXVIZSettings`
+  - `XvizStreamBuffer` -> `XVIZStreamBuffer`
+  - `XvizStyleParser` -> `XVIZStyleParser`
+  - `XvizObject` -> `XVIZObject`
+  - `XvizObjectCollection` -> `XVIZObjectCollection`
 
 #### Non-Breaking changes
 
- - Unstable Protobuf 3 IDL files are in `modules/schema/proto/v2`
- - The 3x3 and 4x4 Matrix types can now be passed flat, because that that is how they are represented in protobuf
- - `ui_panel_info` can now represent the declarative UI content as raw string because that is how protobuf will pass the JSON format of the declarative UI files
- - New XVIZ setting `PLAYBACK_FRAME_RATE`
- - New XVIZ config `TIMESTAMP_FORMAT`
-
+- Unstable Protobuf 3 IDL files are in `modules/schema/proto/v2`
+- The 3x3 and 4x4 Matrix types can now be passed flat, because that that is how they are represented
+  in protobuf
+- `ui_panel_info` can now represent the declarative UI content as raw string because that is how
+  protobuf will pass the JSON format of the declarative UI files
+- New XVIZ setting `PLAYBACK_FRAME_RATE`
+- New XVIZ config `TIMESTAMP_FORMAT`
 
 ## [0.1.0] - 2018-10-24
+
 ### Changes
+
 - XVIZ specification finalization and tooling updates
+
   - [Pose](docs/protocol-schema/core-protocol.md) is now well defined
   - support for CSS like charactor color codes
   - `point` primitive supports per point colors array
@@ -68,13 +79,15 @@ Since everything is explicitly typed now we have:
   - declarative UI spec and documentation added
 
 - [XVIZBuilder API](docs/api-reference/xviz-builder.md) refactor
+
   - `XVIZBuilder.stream()` has split into seperate methods for each XVIZ data category
     - `pose()`
     - `primtive()`
     - `variable()`
     - `timeSeries()`
   - `XVIZBuilder.pose()` has a well-defined type with fluent API
-  - [style properties](docs/protocol-schema/style-specification.md) are snake_case, no longer camelCase
+  - [style properties](docs/protocol-schema/style-specification.md) are snake_case, no longer
+    camelCase
 
 - [XVIZMetadataBuilder](docs/api-reference/xviz-metadata-builder.md) changes
   - `category()` takes singular form
@@ -83,4 +96,5 @@ Since everything is explicitly typed now we have:
   - `coordinate()` and `transform()` support for reference frame support
 
 ## [0.0.1] - 2018-10-24
+
 - Untracked beta development

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*Uber Confidential Information*
+_Uber Confidential Information_
 
 # xviz
 
@@ -10,8 +10,8 @@ XVIZ protocol and utility libraries.
 
 To build this repository you need:
 
- - Node.js, tested with 8.11.3, compatible with 8.x
- - Yarn, tested with 1.7.0, compatible with 1.x
+- Node.js, tested with 8.11.3, compatible with 8.x
+- Yarn, tested with 1.7.0, compatible with 1.x
 
 To install dependencies, run:
 
@@ -37,7 +37,8 @@ $ yarn test-browser
 
 ## Docs
 
-The documentation is built with the Ocular documentation generator. You can easily iterate on the docs by doing, and see changes live in your browser:
+The documentation is built with the Ocular documentation generator. You can easily iterate on the
+docs by doing, and see changes live in your browser:
 
 ```
 $ cd website
@@ -54,7 +55,7 @@ $ yarn build
 
 Then open `dist/index.html` to view.
 
-
 ## Coding Standard
 
-xviz uses a pinned version of the [uber-es2015](https://www.npmjs.com/package/eslint-config-uber-es2015) linter rules.
+xviz uses a pinned version of the
+[uber-es2015](https://www.npmjs.com/package/eslint-config-uber-es2015) linter rules.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,18 +4,19 @@
 
 The XVIZ protocol provides
 
-* Support for synchronization across multiplexed, time sliced data streams
-* A rich set of Geometry Primitives
-* Visual styling using stylesheets
-* Declarative UI components
-* A machine readable JSON scheme definition
+- Support for synchronization across multiplexed, time sliced data streams
+- A rich set of Geometry Primitives
+- Visual styling using stylesheets
+- Declarative UI components
+- A machine readable JSON scheme definition
 
 ## Complementary Code
 
-Once you have encoded your data using the XVIZ protocol, its time to start visualizing it. There is a growing ecosystem with multiple complementary components that you can use stand-alone or in combination.
+Once you have encoded your data using the XVIZ protocol, its time to start visualizing it. There is
+a growing ecosystem with multiple complementary components that you can use stand-alone or in
+combination.
 
-* WebGL2-powered `deck.gl` layers to render 3D visualizations of your data.
-* React components to visualize data as time series and other formats.
-* React components to implement the Declarative UI parts of XVIZ.
-* A machine readable [JSON schema](http://json-schema.org/) in `@xviz/schema` package
-
+- WebGL2-powered `deck.gl` layers to render 3D visualizations of your data.
+- React components to visualize data as time series and other formats.
+- React components to implement the Declarative UI parts of XVIZ.
+- A machine readable [JSON schema](http://json-schema.org/) in `@xviz/schema` package

--- a/docs/api-reference/glb-loader.md
+++ b/docs/api-reference/glb-loader.md
@@ -1,17 +1,20 @@
 # GLBLoader
 
-Provides functions for parsing or generating the binary GLB containers used by glTF (and certain other formats).
+Provides functions for parsing or generating the binary GLB containers used by glTF (and certain
+other formats).
 
-Takes a JavaScript data structure and encodes it as a JSON blob with binary data (e.g. typed arrays) extracted into a binary chunk.
-
+Takes a JavaScript data structure and encodes it as a JSON blob with binary data (e.g. typed arrays)
+extracted into a binary chunk.
 
 ## Functions
 
 ### parseGLB(arrayBuffer : ArrayBuffer) : Object
 
-Parses an in-memory, GLB formatted `ArrayBuffer` into a JavaScript "JSON" data structure with inlined binary data fields.
-
+Parses an in-memory, GLB formatted `ArrayBuffer` into a JavaScript "JSON" data structure with
+inlined binary data fields.
 
 ### encodeGLB(json : Object) : ArrayBuffer
 
-Writes JavaScript JSON data structure into an arrayBuffer that can be written atomically to file, extracting binary fields from the data and placing these in a compact binary chunk following the "stripped" JSON chunk.
+Writes JavaScript JSON data structure into an arrayBuffer that can be written atomically to file,
+extracting binary fields from the data and placing these in a compact binary chunk following the
+"stripped" JSON chunk.

--- a/docs/api-reference/parse-xviz.md
+++ b/docs/api-reference/parse-xviz.md
@@ -1,2 +1,1 @@
 # parseXVIZ
-

--- a/docs/api-reference/xviz-builder.md
+++ b/docs/api-reference/xviz-builder.md
@@ -5,32 +5,38 @@
 ## Constructor
 
 ##### metadata (Object)
-* Use `XVIZMetadataBuilder` to construct metadata object.
+
+- Use `XVIZMetadataBuilder` to construct metadata object.
 
 ##### disableStreams (Array)
-* disableStreams are not flushed to frame.
+
+- disableStreams are not flushed to frame.
 
 ##### validateWarn (Function),
-* called when there is a validation warning.
+
+- called when there is a validation warning.
 
 ##### validateError (Function)
-* called when there is a validation error.
 
+- called when there is a validation error.
 
 ## Methods
+
 All methods except `getFrame()` return `this` builder instance
 
 ##### getFrame()
-* Return an object with xviz protocol containing all the streams in current frame built from the XVIZBuilder instance.
+
+- Return an object with xviz protocol containing all the streams in current frame built from the
+  XVIZBuilder instance.
 
 ##### pose(streamId : String) : XVIZPoseBuilder
-`streamId` is default to `/vehicle_pose` if not specified.
-Also for a frame, stream `/vehicle_pose` must be defined.
-Additional poses can be defined but are not required.
 
-* Start building a `pose` stream.
-* Return `XVIZPoseBuilder` instance
-* `Pose` structure
+`streamId` is default to `/vehicle_pose` if not specified. Also for a frame, stream `/vehicle_pose`
+must be defined. Additional poses can be defined but are not required.
+
+- Start building a `pose` stream.
+- Return `XVIZPoseBuilder` instance
+- `Pose` structure
 
 ```js
 {
@@ -39,37 +45,41 @@ Additional poses can be defined but are not required.
   position: [x, y, z],
   orientation: [roll, pitch, yaw]
 }
-
 ```
 
 ##### primitive(streamId : String) : XVIZPrimitiveBuilder
-* Start building a `primitive` or `future` stream.
-* Return `XVIZPrimitiveBuilder` instance
+
+- Start building a `primitive` or `future` stream.
+- Return `XVIZPrimitiveBuilder` instance
 
 ##### variable(streamId : String) : XVIZVariableBuilder
-* Start building a `variables` stream.
-* Return `XVIZVariableBuilder` instance
+
+- Start building a `variables` stream.
+- Return `XVIZVariableBuilder` instance
 
 ##### timeSeries(streamId : String) : XVIZTimeSeriesBuilder
-* Start building a `timeSeries` stream.
-* Return `XVIZTimeSeriesBuilder` instance
+
+- Start building a `timeSeries` stream.
+- Return `XVIZTimeSeriesBuilder` instance
 
 **Naming rules for `streamId`**
-* Start building a stream.
-* `streamId` has to be path-like.
+
+- Start building a stream.
+- `streamId` has to be path-like.
   - always starts with a `/`
   - sections contain only: `[a-zA-Z0-9_-:.]`
   - does not end with a `/`
 
 Examples:
-   - `/vehicle-pose`
-   - `/vehicle/velocity`
-   - `/object/car-1`
+
+- `/vehicle-pose`
+- `/vehicle/velocity`
+- `/object/car-1`
 
 ##### uiPrimitive(streamId : String) : XVIZUIPrimitiveBuilder
-* Start building a `ui_primitive` stream.
-* Return `XVIZUIPrimitiveBuilder` instance
 
+- Start building a `ui_primitive` stream.
+- Return `XVIZUIPrimitiveBuilder` instance
 
 # XVIZPoseBuilder
 
@@ -78,7 +88,6 @@ Examples:
 ##### position(x: Number, y : Number, z : Number)
 
 ##### orientation(roll: Number, pitch : Number, yaw : Number)
-
 
 # XVIZPrimitiveBuilder
 
@@ -89,63 +98,74 @@ Examples:
 ##### points(vertices : TypedArray)
 
 ##### image(data, format)
-* `data` binary image data
-* `format` e.g. 'png', 'jpg', etc
+
+- `data` binary image data
+- `format` e.g. 'png', 'jpg', etc
 
 ##### dimensions(widthPixel : Number, heightPixel : Number, depth : Number)
-* Only used for `image` primitive, providing dimension info about image stream.
+
+- Only used for `image` primitive, providing dimension info about image stream.
 
 ##### circle(position: Array, radius : Number)
-* `position` has to be an array with length 3, [x, y, z].
+
+- `position` has to be an array with length 3, [x, y, z].
 
 ##### stadium(start : Array, end : Array, radius : Number)
-* Both `start` and `end` are array with length3, [x, y, z].
+
+- Both `start` and `end` are array with length3, [x, y, z].
 
 ##### text(message : String)
 
 ##### position(point : Array)
-* Position has to be an array with length 3.
-* Only used for specifying where to place `text` message.
+
+- Position has to be an array with length 3.
+- Only used for specifying where to place `text` message.
 
 ##### style(style : Object)
+
 check `xviz-stylesheet` for supported style properties
 
 ##### id(id : String)
-* Specify `id` for a primitive.
+
+- Specify `id` for a primitive.
 
 ##### classes(classList : Array)
-* `classList` style classes, should match metadata definition
+
+- `classList` style classes, should match metadata definition
 
 ##### timestamp(timestamp : Number)
-* Primitive with timestamp is considered as `future`.
-* check `core-protocol` for definition of future.
 
+- Primitive with timestamp is considered as `future`.
+- check `core-protocol` for definition of future.
 
 # XVIZVariableBuilder
 
 ##### timestamps(timestamps : Array)
-* Set timestamps of a variable.
+
+- Set timestamps of a variable.
 
 ##### values(values : Any)
-* `values` and `timestamps` should be matched pairs.
-* Each element in `values` array should be `Number`, `String`, or `boolean`.
 
+- `values` and `timestamps` should be matched pairs.
+- Each element in `values` array should be `Number`, `String`, or `boolean`.
 
 # XVIZTimeSeriesBuilder
 
 ##### timestamp(timestamp : Number)
-* Set timestamp.
+
+- Set timestamp.
 
 ##### value(value : Any)
-* Value has to be one of `Number`, `String`, or `boolean`.
 
+- Value has to be one of `Number`, `String`, or `boolean`.
 
 # XVIZUIPrimitiveBuilder
 
 ##### treetable(columns : Array)
 
 Initialize a treetable primitive.
-* `columns` should be an array of descriptors of table columns.
+
+- `columns` should be an array of descriptors of table columns.
 
 ##### row(id: String, column_values: Array)
 
@@ -155,8 +175,8 @@ Add a row to the table. Returns a `XVIZTreeTableRowBuilder` instance that repres
 
 ##### child(id: String, column_values: Array)
 
-Append a row as a child of this row. Returns a `XVIZTreeTableRowBuilder` instance that represents the new row.
-
+Append a row as a child of this row. Returns a `XVIZTreeTableRowBuilder` instance that represents
+the new row.
 
 ## Example
 
@@ -289,5 +309,4 @@ const frame = xvizBuider.getFrame();
     }
   ]
 }
-
 ```

--- a/docs/api-reference/xviz-configuration.md
+++ b/docs/api-reference/xviz-configuration.md
@@ -1,6 +1,5 @@
 # XVIZ Configuration and Settings
 
-
 ## Functions
 
 ### setXVIZConfig(config)
@@ -14,20 +13,21 @@ Constants:
 
 Parser plugins:
 
-- `preProcessPrimitive` (Function) - Pre process a primitive. This can be used to change the type of a primitive (e.g. from `point` to `text`) and/or modify their properties.
+- `preProcessPrimitive` (Function) - Pre process a primitive. This can be used to change the type of
+  a primitive (e.g. from `point` to `text`) and/or modify their properties.
 
 ### getXVIZConfig(config)
 
 Returns the current XVIZ config.
 
-
 ### setXVIZSettings(config)
 
 Sets the XVIZ settings. The default settings are:
 
-- `TIME_WINDOW` (Number) - The maximum time difference allowed for a state update to be associated with a given timestamp. Increase this number to ensure that we cover a sufficient time window for any available data. Default `400`.
+- `TIME_WINDOW` (Number) - The maximum time difference allowed for a state update to be associated
+  with a given timestamp. Increase this number to ensure that we cover a sufficient time window for
+  any available data. Default `400`.
 - `PLAYBACK_FRAME_RATE` (Number) - The number of frames to generate per second. Default `10`.
-
 
 ### getXVIZSettings(config)
 

--- a/docs/api-reference/xviz-loader.md
+++ b/docs/api-reference/xviz-loader.md
@@ -6,17 +6,18 @@
 
 Parses an in-memory, GLB formatted `ArrayBuffer` into XVIZ.
 
-
 ### encodeBinaryXVIZ(json : Object, options : Object) : ArrayBuffer
 
-* `options=` (Object)
-    * `options.flattenArrays`=`true` - Whether to flatten arrays
-    * `options.magic`=`MAGIC_XVIZ` - Magic number (first four bytes in file)
+- `options=` (Object)
+  - `options.flattenArrays`=`true` - Whether to flatten arrays
+  - `options.magic`=`MAGIC_XVIZ` - Magic number (first four bytes in file)
 
 Encodes an XVIZ data structure into an arrayBuffer that can be written atomically to file.
 
-Any typed arrays will be extracted from the JSON payload and stored in the binary chunk at the end of the file.
+Any typed arrays will be extracted from the JSON payload and stored in the binary chunk at the end
+of the file.
 
-If the `flattenArrays` option is not set to `false`, any nested JavaScript array that only contains small arrays of numbers will be flattened to a typed array and stored in binary form.
+If the `flattenArrays` option is not set to `false`, any nested JavaScript array that only contains
+small arrays of numbers will be flattened to a typed array and stored in binary form.
 
 Any arrays that are not typed arrays will be encoded in JSON text form.

--- a/docs/api-reference/xviz-log-slice.md
+++ b/docs/api-reference/xviz-log-slice.md
@@ -1,2 +1,1 @@
 # XVIZLogSlice
-

--- a/docs/api-reference/xviz-metadata-builder.md
+++ b/docs/api-reference/xviz-metadata-builder.md
@@ -2,25 +2,30 @@
 
 `XVIZMetadataBuilder` class helps generate metadata object
 
-
 ## Methods
 
 ###### getMetadata() : Object
+
 Return `metadata` object.
 
 ###### startTime(time : Number)
+
 Set log start time.
 
 ###### endTime(time : Number)
+
 Set log end time.
 
 ###### ui(uiBuilder : XVIZUIBuilder)
+
 Set the configuration of declarative UI.
 
 ###### stream(streamId : String)
+
 Add a stream.
 
 ###### category(category : String)
+
 Set `category` of the stream. Options are
 
 - `primitive`
@@ -29,54 +34,63 @@ Set `category` of the stream. Options are
 
 See `core-protocol` for details.
 
-
 ###### type(type : String)
+
 Set type of the stream.
 
 For category `variable` and `time_series`, options are
+
 - `float`
 - `integer`
 - `string`
-- `boolean`
-check `core-protocol` for details.
+- `boolean` check `core-protocol` for details.
 
 For `primitive`, options are
+
 - `point`
 - `polygon`
 - `polyline`
 - `circle`
 - `stadium`
 - `text`
-- `image`
-check `geometry-primitives` for details.
-
+- `image` check `geometry-primitives` for details.
 
 ###### unit(unit : String)
+
 Set unit for `variable` or `time_series`. e.g. `m/s`, `m/s^2`
 
 ###### coordinate(coordinate : String)
+
 Set the coordinate for a stream.
 
 `vehicle_relative`, `map_relative` or any customized name.
 
 ###### transformMatrix(matrix: Matrix4 | Array)
-Add a custom transform matrix.  In order to make a relative adjustment from the core pose of the stream.
-`matrix` could be an Matrix4 ([math.gl](https://github.com/uber-web/math.gl/blob/master/docs/api-reference/matrix4.md)) instance or an array of 16 numbers.
+
+Add a custom transform matrix. In order to make a relative adjustment from the core pose of the
+stream. `matrix` could be an Matrix4
+([math.gl](https://github.com/uber-web/math.gl/blob/master/docs/api-reference/matrix4.md)) instance
+or an array of 16 numbers.
 
 ###### pose(position: Object, orientation: Object)
-`position`: `{x, y, z}`
-`orientation`: `{roll, pitch, yaw}`
 
-Stream data from sensors can have a pose offset relative to the vehicle pose. `pose` is a convenient function we have to day to construct a transform matrix from a pose definition.
+`position`: `{x, y, z}` `orientation`: `{roll, pitch, yaw}`
 
-`position` and `orientation` will be used to construct a [Pose](https://github.com/uber-web/math.gl/blob/master/src/pose.js) instance and applied to a identity matrix.
+Stream data from sensors can have a pose offset relative to the vehicle pose. `pose` is a convenient
+function we have to day to construct a transform matrix from a pose definition.
+
+`position` and `orientation` will be used to construct a
+[Pose](https://github.com/uber-web/math.gl/blob/master/src/pose.js) instance and applied to a
+identity matrix.
 
 **Note:** Both `pose` and `transformMatrix` can not be applied at the same time.
 
 ###### streamStyle(style : Object)
+
 Define default style with style object.
 
 ###### styleClass(className : String, style : Object)
+
 Define a style class with style object.
 
 Refer `style-specification` for supported style properties.

--- a/docs/api-reference/xviz-object-collection.md
+++ b/docs/api-reference/xviz-object-collection.md
@@ -1,3 +1,1 @@
 # XVIZObjectCollection
-
-

--- a/docs/api-reference/xviz-object.md
+++ b/docs/api-reference/xviz-object.md
@@ -6,7 +6,6 @@ The `XVIZObject` class tracks the status of each XVIZ object in a log.
 import {XVIZObject} from 'viz';
 ```
 
-
 ## Static Methods
 
 ##### `get(id)`
@@ -21,7 +20,6 @@ Returns all XVIZ objects in the current log. Keys are ids and values are `XVIZOb
 
 Returns all XVIZ objects in the current frame. Keys are ids and values are `XVIZObject` instances.
 
-
 ## Properties
 
 ##### `id` (string)
@@ -34,16 +32,17 @@ The app state of the object, such as `tracked` and `selected`.
 
 ##### `props` (Map)
 
-The properties of the object from the XVIZ log, such as `label` and `soc`. `props` is empty if the object does not exist in the current frame.
+The properties of the object from the XVIZ log, such as `label` and `soc`. `props` is empty if the
+object does not exist in the current frame.
 
 ##### `position` (array)
 
-The coordinates of the tracking point of the object. `undefined` if the object does not exist in the current frame.
+The coordinates of the tracking point of the object. `undefined` if the object does not exist in the
+current frame.
 
 ##### `isValid` (bool)
 
 `true` if the object is in the current frame.
-
 
 ## Methods
 

--- a/docs/api-reference/xviz-synchronizer.md
+++ b/docs/api-reference/xviz-synchronizer.md
@@ -1,8 +1,7 @@
 # XVIZSynchronizer class
 
-This class is constructed with a map of logs, and enables the application
-to set a timestamp and retrieve one datums from every log that "matches"
-that timestamp.
+This class is constructed with a map of logs, and enables the application to set a timestamp and
+retrieve one datums from every log that "matches" that timestamp.
 
-Makes it easy to walk a set of non-synchronized logs and get the combined
-list of all the geometry primitives from the most relevant datum in each log.
+Makes it easy to walk a set of non-synchronized logs and get the combined list of all the geometry
+primitives from the most relevant datum in each log.

--- a/docs/api-reference/xviz-trajectory-helper.md
+++ b/docs/api-reference/xviz-trajectory-helper.md
@@ -1,32 +1,36 @@
-# XVIZTrajectoryHelper 
+# XVIZTrajectoryHelper
 
 Provide helper functions to generate trajectory for pose and objects.
 
 ## Functions
 
 ### getRelativeCoordinates(vertices : Array, basePose : Object) : Array
+
 Given vertices and a base pose, transform the vertices to `basePose` relative coordinates
-  * `vertices: Array`, array of [x, y, z]
-  * `basePose: Object`, {x, y, z, longitude, latitude, altitude, roll, pitch, yaw}
+
+- `vertices: Array`, array of [x, y, z]
+- `basePose: Object`, {x, y, z, longitude, latitude, altitude, roll, pitch, yaw}
 
 ### getPoseTrajectory(input: object) : Array
+
 Generate trajectory for list of poses with given start frame and end frame
 
-* `input` object should contain the following properties
-  * `poses: Array`, array of `Pose` entries
-    * each pose should have `x, y, z, longitude, latitude, altitude, roll, pitch, yaw`
-  * `startFrame: Number`, start frame number of trajectory
-  * `endFrame: Number`, end frame number of trajectory
+- `input` object should contain the following properties
+  - `poses: Array`, array of `Pose` entries
+    - each pose should have `x, y, z, longitude, latitude, altitude, roll, pitch, yaw`
+  - `startFrame: Number`, start frame number of trajectory
+  - `endFrame: Number`, end frame number of trajectory
 
 ### getObjectTrajectory(input: object) : Array
+
 Generate object trajectory in pose relative coordinates
 
-* `input` object should contain the following properties
-  * `targetObject: Object`, the `object` to generate trajectory
-    * object should have `id, x, y, z`
-  * `objectFrames: Array`, all the frames with objects
-    * each object should have `id, x, y, z`
-  * `poseFrames: Array`, all the frames with base poses
-    * each pose should have `x, y, z, longitude, latitude, altitude, roll, pitch, yaw`
-  * `startFrame: Number`, start frame number of trajectory
-  * `endFrame: Number`, end frame number of trajectory
+- `input` object should contain the following properties
+  - `targetObject: Object`, the `object` to generate trajectory
+    - object should have `id, x, y, z`
+  - `objectFrames: Array`, all the frames with objects
+    - each object should have `id, x, y, z`
+  - `poseFrames: Array`, all the frames with base poses
+    - each pose should have `x, y, z, longitude, latitude, altitude, roll, pitch, yaw`
+  - `startFrame: Number`, start frame number of trajectory
+  - `endFrame: Number`, end frame number of trajectory

--- a/docs/api-reference/xviz-ui-builder.md
+++ b/docs/api-reference/xviz-ui-builder.md
@@ -16,45 +16,39 @@ Root
  ┗━ Panel
 ```
 
-* UI root has a list of `panel`s
-* [Panel](#XVIZPannelBuilder) has children, which could be either *component* or *container*
-* [Container](#XVIZContainerBuilder) children could be either *component* or *container*
-* Component could be one of the following types:
+- UI root has a list of `panel`s
+- [Panel](#XVIZPannelBuilder) has children, which could be either _component_ or _container_
+- [Container](#XVIZContainerBuilder) children could be either _component_ or _container_
+- Component could be one of the following types:
   - [Metric](#XVIZMetricBuilder)
   - [TreeTable](#XVIZTreeTableBuilder)
   - [Table](#XVIZTableBuilder)
   - [Plot](#XVIZPlotBuilder)
   - [Video](#XVIZVideoBuilder)
 
-
 ## Example
 
 ```js
-import { XVIZUIBuilder } from '@xviz/builder';
+import {XVIZUIBuilder} from '@xviz/builder';
 const builder = new XVIZUIBuilder({});
 
 const builder = new XVIZUIBuilder({});
 
-const panel = builder
-  .panel({name: 'Metrics Panel'});
+const panel = builder.panel({name: 'Metrics Panel'});
 
-const container = builder
-  .container({name: 'Metrics Container 1'});
+const container = builder.container({name: 'Metrics Container 1'});
 
-const metrics1 = builder
-  .metric({streams: ['/vehicle/velocity']})
-  .title('Velocity');
+const metrics1 = builder.metric({streams: ['/vehicle/velocity']}).title('Velocity');
 
-const metrics2 = builder
-  .metric({streams: ['/vehicle/acceleration']})
-  .title('Acceleration');
+const metrics2 = builder.metric({streams: ['/vehicle/acceleration']}).title('Acceleration');
 
-container.child(metrics1)
+container.child(metrics1);
 container.child(metrics2);
 builder.child(panel).child(container);
 ```
 
 Output:
+
 ```js
 builder.getUI();
 /* returns:
@@ -97,38 +91,48 @@ new XVIZUIBuilder(options);
 
 Parameters:
 
-* **options.validateWarn** (Function) - called when there is a validation warning. Default is `console.warn`.
-* **options.validateError** (Function) - called when there is a validation error. Default is `console.error`.
+- **options.validateWarn** (Function) - called when there is a validation warning. Default is
+  `console.warn`.
+- **options.validateError** (Function) - called when there is a validation error. Default is
+  `console.error`.
 
 ### Methods
 
 ##### child(panel)
+
 Append a [`XVIZPannelBuilder`](#XVIZPannelBuilder) instance to the root. Returns the child.
 
 ##### getUI()
+
 Returns a JSON descriptor of all UI components.
 
 ##### panel(options)
+
 Returns a new [`XVIZPannelBuilder`](#XVIZPannelBuilder) instance with the specified options.
 
 ##### container(options)
+
 Returns a new [`XVIZContainerBuilder`](#XVIZContainerBuilder) instance with the specified options.
 
 ##### metric(options)
+
 Returns a new [`XVIZMetricBuilder`](#XVIZMetricBuilder) instance with the specified options.
 
 ##### table(options)
+
 Returns a new [`XVIZTableBuilder`](#XVIZTableBuilder) instance with the specified options.
 
 ##### treetable(options)
+
 Returns a new [`XVIZTreeTableBuilder`](#XVIZTreeTableBuilder) instance with the specified options.
 
 ##### plot(options)
+
 Returns a new [`XVIZPlotBuilder`](#XVIZPlotBuilder) instance with the specified options.
 
 ##### video(options)
-Returns a new [`XVIZVideoBuilder`](#XVIZVideoBuilder) instance with the specified options.
 
+Returns a new [`XVIZVideoBuilder`](#XVIZVideoBuilder) instance with the specified options.
 
 ## XVIZPanelBuilder
 
@@ -141,16 +145,19 @@ new XVIZPanelBuilder(options);
 ```
 
 Parameters:
-* **options.name** (String)
-* **options.layout** (String) - `vertical` or `horizontal`.
-* **options.interactions** (String) - `reorderable` or `drag_out`
+
+- **options.name** (String)
+- **options.layout** (String) - `vertical` or `horizontal`.
+- **options.interactions** (String) - `reorderable` or `drag_out`
 
 ### Methods
 
 ##### child(node)
+
 Append a container or a component to the panel. Returns the child.
 
 ##### getUI()
+
 Returns a JSON descriptor of this panel.
 
 ## XVIZContainerBuilder
@@ -164,18 +171,20 @@ new XVIZContainerBuilder(options);
 ```
 
 Parameters:
-* **options.name** (String)
-* **options.layout** (String) - `vertical` or `horizontal`.
-* **options.interactions** (String) - `reorderable` or `drag_out`
+
+- **options.name** (String)
+- **options.layout** (String) - `vertical` or `horizontal`.
+- **options.interactions** (String) - `reorderable` or `drag_out`
 
 ### Methods
 
 ##### child(panel)
+
 Append a container or a component to the container.
 
 ##### getUI()
-Returns a JSON descriptor of this container.
 
+Returns a JSON descriptor of this container.
 
 ## XVIZMetricBuilder
 
@@ -188,15 +197,16 @@ new XVIZMetricBuilder(options);
 ```
 
 Parameters:
-* **options.title** (String) - title of the metrics card
-* **options.description** (String) - description of the metrics card
-* **options.streams** (Array) - a list of variable streams to visualize
+
+- **options.title** (String) - title of the metrics card
+- **options.description** (String) - description of the metrics card
+- **options.streams** (Array) - a list of variable streams to visualize
 
 ### Methods
 
 ##### getUI()
-Returns a JSON descriptor of this component.
 
+Returns a JSON descriptor of this component.
 
 ## XVIZPlotBuilder
 
@@ -209,16 +219,17 @@ new XVIZPlotBuilder(options);
 ```
 
 Parameters:
-* **options.title** (String) - title of the plot
-* **options.description** (String) - description of the plot
-* **options.independentVariable** (String) - the independent variable stream
-* **options.dependentVariable** (Array) - a list of dependent variable streams
+
+- **options.title** (String) - title of the plot
+- **options.description** (String) - description of the plot
+- **options.independentVariable** (String) - the independent variable stream
+- **options.dependentVariable** (Array) - a list of dependent variable streams
 
 ### Methods
 
 ##### getUI()
-Returns a JSON descriptor of this component.
 
+Returns a JSON descriptor of this component.
 
 ## XVIZTableBuilder
 
@@ -231,16 +242,17 @@ new XVIZTableBuilder(options);
 ```
 
 Parameters:
-* **options.title** (String) - title of the plot
-* **options.description** (String) - description of the plot
-* **options.stream** (String) - the stream that contains the table data
-* **options.displayObjectId** (boolean) - whether to display the object ID column
+
+- **options.title** (String) - title of the plot
+- **options.description** (String) - description of the plot
+- **options.stream** (String) - the stream that contains the table data
+- **options.displayObjectId** (boolean) - whether to display the object ID column
 
 ### Methods
 
 ##### getUI()
-Returns a JSON descriptor of this component.
 
+Returns a JSON descriptor of this component.
 
 ## XVIZTreeTableBuilder
 
@@ -253,16 +265,17 @@ new XVIZTreeTableBuilder(options);
 ```
 
 Parameters:
-* **options.title** (String) - title of the plot
-* **options.description** (String) - description of the plot
-* **options.stream** (String) - the stream that contains the table data
-* **options.displayObjectId** (boolean) - whether to display the object ID column
+
+- **options.title** (String) - title of the plot
+- **options.description** (String) - description of the plot
+- **options.stream** (String) - the stream that contains the table data
+- **options.displayObjectId** (boolean) - whether to display the object ID column
 
 ### Methods
 
 ##### getUI()
-Returns a JSON descriptor of this component.
 
+Returns a JSON descriptor of this component.
 
 ## XVIZVideoBuilder
 
@@ -275,9 +288,11 @@ new XVIZVideoBuilder(options);
 ```
 
 Parameters:
-* **options.cameras** (Array) - a list of streams to render as video
+
+- **options.cameras** (Array) - a list of streams to render as video
 
 ### Methods
 
 ##### getUI()
+
 Returns a JSON descriptor of this component.

--- a/docs/api-reference/xviz-validator.md
+++ b/docs/api-reference/xviz-validator.md
@@ -6,7 +6,6 @@
 
 Automatically loads schema data.
 
-
 ## Methods
 
 All validation methods throw if the object fails to validate.
@@ -27,7 +26,6 @@ Validate `state_update` message.
 
 Validate `stream_set` type.
 
-
 ### Validate base types
 
 #### `validatePose(data : Object)`
@@ -36,9 +34,8 @@ Validate `stream_set` type.
 
 Validate the different primitive types.
 
- - `type` - the type of the variable, like "point" or "circle", see spec
- - `data` - the object to validate
-
+- `type` - the type of the variable, like "point" or "circle", see spec
+- `data` - the object to validate
 
 #### `validateTimeSeries(data : Object)`
 
@@ -50,9 +47,8 @@ Validate the different primitive types.
 
 Validation the different annotation types.
 
- - `type` - the type of the variable, only "visual" is currently valid
- - `data` - the object to validate
-
+- `type` - the type of the variable, only "visual" is currently valid
+- `data` - the object to validate
 
 ### Uility methods
 
@@ -60,8 +56,8 @@ Validation the different annotation types.
 
 Validate any schema
 
- - `schemaName` - the name of the schema, the ".schema.json" trailer is not needed
- - `data` - the object to validate
+- `schemaName` - the name of the schema, the ".schema.json" trailer is not needed
+- `data` - the object to validate
 
 #### `schemaCount() : Number`
 

--- a/docs/developers-guide/README.md
+++ b/docs/developers-guide/README.md
@@ -5,8 +5,8 @@ XVIZ comes with a number of tools to help you generated, validate, parse and sty
 This guide will show you how to use these tools to convert your data into XVIZ.
 
 This includes:
- - Explaining what data is required
- - How streams, object, and time are managed in XVIZ
- - Explaining *frames* and it they relate to time and streams
- - How UI elements can be created in XVIZ
 
+- Explaining what data is required
+- How streams, object, and time are managed in XVIZ
+- Explaining _frames_ and it they relate to time and streams
+- How UI elements can be created in XVIZ

--- a/docs/developers-guide/generating-xviz.md
+++ b/docs/developers-guide/generating-xviz.md
@@ -1,6 +1,5 @@
 # Generating XVIZ
 
-
 ## Generating XVIZ metadata
 
 ```js
@@ -33,7 +32,6 @@ builder
   .polygon(verts2)
   .timestamp(ts2);
 ```
-
 
 ## Generating XVIZ declarative UI
 

--- a/docs/developers-guide/installing-xviz.md
+++ b/docs/developers-guide/installing-xviz.md
@@ -1,13 +1,13 @@
 # Installation
 
-Depending on whether you intend to produce (generate/write) XVIZ, validate XVIZ or consume (load and parse) XVIZ, you will want to install the appropriate XVIZ library:
+Depending on whether you intend to produce (generate/write) XVIZ, validate XVIZ or consume (load and
+parse) XVIZ, you will want to install the appropriate XVIZ library:
 
-| NPM module      | Description |
-| ---             | --- |
-| `@xviz/builder` | Classes to help build and write XVIZ data |
+| NPM module      | Description                                       |
+| --------------- | ------------------------------------------------- |
+| `@xviz/builder` | Classes to help build and write XVIZ data         |
 | `@xviz/parser`  | Classes for parsing and post processing XVIZ data |
-| `@xviz/schema`  | JSON schemas for validating XVIZ JSON data |
-
+| `@xviz/schema`  | JSON schemas for validating XVIZ JSON data        |
 
 E.g. to start generating XVIZ using the builder API:
 

--- a/docs/developers-guide/parsing-xviz.md
+++ b/docs/developers-guide/parsing-xviz.md
@@ -1,16 +1,18 @@
 # Parsing XVIZ
 
-While a majority of XVIZ users are expected to want to generate (or convert existing data to) XVIZ in order to display it in an existing client UI, some applications will want to load and parse XVIZ, e.g. to implement custom display, post-processing or conversion.
-
+While a majority of XVIZ users are expected to want to generate (or convert existing data to) XVIZ
+in order to display it in an existing client UI, some applications will want to load and parse XVIZ,
+e.g. to implement custom display, post-processing or conversion.
 
 ## Loading XVIZ
 
-XVIZ is intended to be served over socket in GLB file sized message chunks, but can also be read from file or via network requests.
-
+XVIZ is intended to be served over socket in GLB file sized message chunks, but can also be read
+from file or via network requests.
 
 ## Parsing Steps
 
-For XVIZ that is stored in binary GLB file format, the binary GLB file must be unpacked, the binary chunks must be rehydrated in to more convenient (JavaScript) objects and typed arrays.
+For XVIZ that is stored in binary GLB file format, the binary GLB file must be unpacked, the binary
+chunks must be rehydrated in to more convenient (JavaScript) objects and typed arrays.
 
-Then postprocessing will take place to ensure the data is in a standardized, easy to work with format, and also apply some application configuration, for instance filtering certain streams etc.
-
+Then postprocessing will take place to ensure the data is in a standardized, easy to work with
+format, and also apply some application configuration, for instance filtering certain streams etc.

--- a/docs/developers-guide/serving-xviz.md
+++ b/docs/developers-guide/serving-xviz.md
@@ -1,7 +1,11 @@
 # Serving XVIZ
 
-XVIZ is intended to be served in a streaming fashion, enabling the ability to load and discard data as needed, enabling "infinite" playback, and also to seek to specific timestamps and restart streaming from that point.
+XVIZ is intended to be served in a streaming fashion, enabling the ability to load and discard data
+as needed, enabling "infinite" playback, and also to seek to specific timestamps and restart
+streaming from that point.
 
-At the moment, the small streaming server in the examples in [streetscape.gl](https://github.com/uber/streetscape.gl) may be the best way to get started.
+At the moment, the small streaming server in the examples in
+[streetscape.gl](https://github.com/uber/streetscape.gl) may be the best way to get started.
 
-Note that for small XVIZ data sets, it is possible to load the entire data set into a client using one or more requests, but for larger data sets, streaming is typically required.
+Note that for small XVIZ data sets, it is possible to load the entire data set into a client using
+one or more requests, but for larger data sets, streaming is typically required.

--- a/docs/developers-guide/structure-of-xviz.md
+++ b/docs/developers-guide/structure-of-xviz.md
@@ -2,26 +2,33 @@
 
 This is a brief summary of [XVIZ concepts](./docs/overview/concepts.md),
 
-
 ## File Structure
 
 ### GLB files
 
-XVIZ is encoded into binary GLB files. The GLB files are containers (or "envelopes") that hold a JSON encoded data structure and a number of binary chunks, typically representing JPEG or PNG encoded images and big geometries like point clouds.
+XVIZ is encoded into binary GLB files. The GLB files are containers (or "envelopes") that hold a
+JSON encoded data structure and a number of binary chunks, typically representing JPEG or PNG
+encoded images and big geometries like point clouds.
 
 ### Frames
 
-Various datums with range of timestamps inside a given time window are collected into a "frame", typically containing one timestamp of each datum type.
+Various datums with range of timestamps inside a given time window are collected into a "frame",
+typically containing one timestamp of each datum type.
 
-Per "convention", one frame of data is encoded in one `.glb` file, which allows a streaming server to simply send one GLB file per message over the socket. That said it is possible to store multiple frames in each GLB file.
+Per "convention", one frame of data is encoded in one `.glb` file, which allows a streaming server
+to simply send one GLB file per message over the socket. That said it is possible to store multiple
+frames in each GLB file.
 
 ### Streams
 
-A frame can contain multiple streams. This makes it easy to allow multiple data producers to write into the same frame and makes it easy for the client to distinguish data from different producers.
+A frame can contain multiple streams. This makes it easy to allow multiple data producers to write
+into the same frame and makes it easy for the client to distinguish data from different producers.
 
-Note that all streams contain the same type of data (geometrical primitives, variables etc), so clients can just combine the data from all streams and display it, without knowing what the actual streams are.
+Note that all streams contain the same type of data (geometrical primitives, variables etc), so
+clients can just combine the data from all streams and display it, without knowing what the actual
+streams are.
 
 ### JSON files
 
-XVIZ can also be encoded in JSON. The advantages of binary encoding large data is lost, but the broad array of tools available to manipulate and inspect JSON are useful when troubleshooting.
-
+XVIZ can also be encoded in JSON. The advantages of binary encoding large data is lost, but the
+broad array of tools available to manipulate and inspect JSON are useful when troubleshooting.

--- a/docs/developers-guide/styling-xviz.md
+++ b/docs/developers-guide/styling-xviz.md
@@ -4,7 +4,8 @@ Styling in XVIZ happens at multiple levels.
 
 ## Object inline styles
 
-Object styling is defined during conversion using the XVIZBuilder.style() method. Simply pass an object with the appropriate style properties and values.
+Object styling is defined during conversion using the XVIZBuilder.style() method. Simply pass an
+object with the appropriate style properties and values.
 
 ## Stream style classes
 
@@ -15,7 +16,9 @@ Using classes requires coordination at two places.
 
 ## Stream style defaults
 
-Stream styles definition define the default style property values for all objects within a stream. They provide a single place to define styles for a stream and avoid unnecessary styling of individual element.
+Stream styles definition define the default style property values for all objects within a stream.
+They provide a single place to define styles for a stream and avoid unnecessary styling of
+individual element.
 
 # Style Specification
 

--- a/docs/developers-guide/using-declarative-ui.md
+++ b/docs/developers-guide/using-declarative-ui.md
@@ -1,23 +1,26 @@
 # Using the Declarative UI
 
-XVIZ allows the producer to declartively connect strams to UI components like control widgets, tables, charts, and tree-views. These UI components can be rendered by the XVIZ client, and can be used to provide additional information beyond what can be captured in the primary 3D scene.
+XVIZ allows the producer to declartively connect strams to UI components like control widgets,
+tables, charts, and tree-views. These UI components can be rendered by the XVIZ client, and can be
+used to provide additional information beyond what can be captured in the primary 3D scene.
 
-The easiest way to add declarative UI components to your XVIZ in JavaScript is to use the `XVizUIBuilder` class.
+The easiest way to add declarative UI components to your XVIZ in JavaScript is to use the
+`XVizUIBuilder` class.
 
 ```js
 const builder = new XVIZDeclarativeUIBuilder({});
 
 builder
-.panel('Metrics')
-.container('child-1')
+  .panel('Metrics')
+  .container('child-1')
 
-.metric('child-1-1')
-.title('Acceleration')
-.end()
+  .metric('child-1-1')
+  .title('Acceleration')
+  .end()
 
-.metric('child-1-2')
-.title('Velocity')
-.end()
+  .metric('child-1-2')
+  .title('Velocity')
+  .end()
 
-.end();
+  .end();
 ```

--- a/docs/developers-guide/using-xviz-in-other-languages.md
+++ b/docs/developers-guide/using-xviz-in-other-languages.md
@@ -1,3 +1,4 @@
 # Using XVIZ in other languages
 
-The initial version of XVIZ has focused on provided strong JavaScript support for generating and consuming XVIZ.
+The initial version of XVIZ has focused on provided strong JavaScript support for generating and
+consuming XVIZ.

--- a/docs/developers-guide/validating-xviz.md
+++ b/docs/developers-guide/validating-xviz.md
@@ -1,6 +1,5 @@
 # Validating XVIZ
 
-
 ## Validating XVIZ metadata
 
 ```js
@@ -10,7 +9,7 @@ const validator = new XVIZValidator();
 
 // Throws on error
 metadata = {
-  version: "2.0.0"
+  version: '2.0.0'
 };
 
 validator.validatorMetadata(metadata);
@@ -27,7 +26,7 @@ const builder = new XVIZBuilder();
 builder
   .pose()
   .timestamp(ts1);
-builder  
+builder
   .primitive('/test/polygon')
   .timestamp(ts1)
   .polygon([[0, 0, 0], [4, 0, 0], [4, 3, 0]]);

--- a/modules/schema/README.md
+++ b/modules/schema/README.md
@@ -1,6 +1,7 @@
 # @xviz/schema
 
-This modulle contains the XVIZ protocol JSON schema files and examples along with utilities for validating them.
+This modulle contains the XVIZ protocol JSON schema files and examples along with utilities for
+validating them.
 
 ## Install
 
@@ -20,15 +21,15 @@ yarn add @xviz/schema
 
 The root of this modules contains the schema divided up into:
 
- * `core` - central types
- * `primitives` - base visualization types
- * `session` - typical client/server messages
- * `math` - basic math types used in several schemas
+- `core` - central types
+- `primitives` - base visualization types
+- `session` - typical client/server messages
+- `math` - basic math types used in several schemas
 
 The non schema directories:
 
- * `src` - code to validate the examples against the schema
- * `examples` - JSON files that match correspondingly named schema files
- * `invalid` - Like `examples` but all of these should fail invalidation
+- `src` - code to validate the examples against the schema
+- `examples` - JSON files that match correspondingly named schema files
+- `invalid` - Like `examples` but all of these should fail invalidation
 
 For more in depth documentation see http://xviz.org/docs

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,9 +29,17 @@ case $MODE in
     echo "Checking prettier code styles..."
 
     JS_PATTERN="{modules,test,website}/**/*.js"
-    DOCS_PATTERN="docs/{overview,protocol-formats,protocol-schema}/**/*.md"
+    DOCS_PATTERN="docs/**/*.md"
+    README_PATTERN="*.md"
+    SCHEMA_README="./modules/schema/README.md"
 
-    npx prettier-check "$JS_PATTERN" "$DOCS_PATTERN" || echo "Running prettier." && npx prettier --write "$JS_PATTERN" "$DOCS_PATTERN"  --loglevel warn
+    npx prettier-check "$JS_PATTERN" "$DOCS_PATTERN" "$README_PATTERN" "$SCHEMA_README" \
+        || echo "Running prettier." && npx prettier --loglevel warn --write \
+                                           "$JS_PATTERN" \
+                                           "$DOCS_PATTERN" \
+                                           "$README_PATTERN" \
+                                           "$SCHEMA_README"
+
 
     echo "Running eslint..."
     npx eslint modules test


### PR DESCRIPTION
We are already doing this for the protocol docs, this updates all the
rest so the format can stay consistent with multiple editors.