### PR TITLE
Uniformly name Plot's property "dependentVariables"

### DIFF
--- a/docs/api-reference/xviz-ui-builder.md
+++ b/docs/api-reference/xviz-ui-builder.md
@@ -223,7 +223,7 @@ Parameters:
 - **options.title** (String) - title of the plot
 - **options.description** (String) - description of the plot
 - **options.independentVariable** (String) - the independent variable stream
-- **options.dependentVariable** (Array) - a list of dependent variable streams
+- **options.dependentVariables** (Array) - a list of dependent variable streams
 
 ### Methods
 

--- a/docs/protocol-schema/declarative-ui.md
+++ b/docs/protocol-schema/declarative-ui.md
@@ -248,7 +248,7 @@ _TODO: screenshot: streetscape.gl demo app showing normal variable plot_
 | **Name**              | **Type**          | **Description**                                                                         |
 | --------------------- | ----------------- | --------------------------------------------------------------------------------------- |
 | `independentVariable` | `stream_id`       | The stream to use as the X axis.                                                        |
-| `dependentVariable`   | `list<stream_id>` | The streams to plot on the Y axis as a function of the stream that makes up the X axis. |
+| `dependentVariables`  | `list<stream_id>` | The streams to plot on the Y axis as a function of the stream that makes up the X axis. |
 | `title`               | `string`          | Shown at the top of the plot                                                            |
 | `description`         | `string`          | Displayed when hovering over the title                                                  |
 

--- a/modules/builder/src/builders/declarative-ui/xviz-plot-builder.js
+++ b/modules/builder/src/builders/declarative-ui/xviz-plot-builder.js
@@ -4,7 +4,7 @@ import {UI_TYPES} from './constants';
 export default class XVIZPlotBuilder extends XVIZBaseUiBuilder {
   constructor({
     independentVariable,
-    dependentVariable,
+    dependentVariables,
     description,
     title,
     validateWarn,
@@ -16,7 +16,7 @@ export default class XVIZPlotBuilder extends XVIZBaseUiBuilder {
       validateError
     });
     this._independentVariable = independentVariable;
-    this._dependentVariable = dependentVariable;
+    this._dependentVariables = dependentVariables;
     this._description = description;
     this._title = title;
 
@@ -24,15 +24,19 @@ export default class XVIZPlotBuilder extends XVIZBaseUiBuilder {
   }
 
   _validate() {
-    if (!this._name) {
-      this._validateError('Panel should have `name`.');
+    if (this._independentVariable) {
+      if (!this._dependentVariables) {
+        this._validateError('Plot should have `dependentVariables`.');
+      }
+    } else {
+      this._validateError('Plot should have `independentVariable`.');
     }
   }
 
   getUI() {
     const obj = super.getUI();
     obj.independentVariable = this._independentVariable;
-    obj.dependentVariable = this._dependentVariable;
+    obj.dependentVariables = this._dependentVariables;
 
     if (this._title) {
       obj.title = this._title;

--- a/modules/schema/declarative-ui/components/plot.schema.json
+++ b/modules/schema/declarative-ui/components/plot.schema.json
@@ -11,7 +11,7 @@
     "independentVariable": {
       "type": "string"
     },
-    "dependentVariable": {
+    "dependentVariables": {
       "type": "array",
       "items": {
         "type": "string"
@@ -24,7 +24,7 @@
     "type",
     "title",
     "independentVariable",
-    "dependentVariable"
+    "dependentVariables"
   ],
   "additionalProperties": false
 }

--- a/modules/schema/examples/declarative-ui/components/plot/simple.json
+++ b/modules/schema/examples/declarative-ui/components/plot/simple.json
@@ -3,7 +3,7 @@
   "title": "Some Other Streams vs Some Stream",
   "description": "The change in some streams as a function of the other one",
   "independentVariable": "/some/stream",
-  "dependentVariable": [
+  "dependentVariables": [
     "/some/other_stream",
     "/some/second_other_stream"
   ]

--- a/modules/schema/examples/declarative-ui/panel/complete.json
+++ b/modules/schema/examples/declarative-ui/panel/complete.json
@@ -4,6 +4,7 @@
   "name": "Example Panel",
   "interactions": ["reorderable"],
   "children": [
+
     {
       "type": "container",
       "layout": "horizontal",
@@ -22,7 +23,7 @@
           "title": "A nested plot!",
           "description": "The change in some streams as a function of the other one",
           "independentVariable": "/some/stream",
-          "dependentVariable": [
+          "dependentVariables": [
             "/some/other_stream",
             "/some/second_other_stream"
           ]
@@ -38,6 +39,7 @@
         }
       ]
     },
+
     {
       "type": "table",
       "title": "A table showing something",
@@ -45,6 +47,7 @@
       "displayObjectId": true,
       "stream": "/prediction/some_table"
     },
+
     {
       "type": "metric",
       "title": "Some metric",
@@ -54,16 +57,18 @@
         "/some_value/commanded"
       ]
     },
+
     {
       "type": "plot",
       "title": "Some Other Streams vs Some Stream",
       "description": "The change in some streams as a function of the other one",
       "independentVariable": "/some/stream",
-      "dependentVariable": [
+      "dependentVariables": [
         "/some/other_stream",
         "/some/second_other_stream"
       ]
     },
+
     {
       "type": "video",
       "cameras": [
@@ -72,6 +77,7 @@
         "rear-port-roof-camera"
       ]
     },
+
     {
       "type": "treetable",
       "title": "A TreeTable!",
@@ -79,5 +85,6 @@
       "displayObjectId": false,
       "stream": "/some/stream/of/treetable/primmatives"
     }
+
   ]
 }

--- a/test/modules/builder/builders/xviz-declare-ui-builder.spec.js
+++ b/test/modules/builder/builders/xviz-declare-ui-builder.spec.js
@@ -4,6 +4,14 @@ import {XVIZValidator} from '@xviz/schema';
 
 const schemaValidator = new XVIZValidator();
 
+function validateUIBuilderOutput(results) {
+  for (const name in results) {
+    if (results.hasOwnProperty(name)) {
+      schemaValidator.validate('declarative-ui/panel', results[name]);
+    }
+  }
+}
+
 test('XVIZBaseUIBuilder', t => {
   const builder = new XVIZUIBuilder({});
 
@@ -51,11 +59,40 @@ test('XVIZBaseUIBuilder', t => {
 
   t.deepEqual(actual, expected, 'XVIZUIBuilder should match expectation');
 
-  for (const name in actual) {
-    if (actual.hasOwnProperty(name)) {
-      schemaValidator.validate('declarative-ui/panel', actual[name]);
+  validateUIBuilderOutput(actual);
+
+  t.end();
+});
+
+test('XVIZUIBuilder#plot basic', t => {
+  const builder = new XVIZUIBuilder({});
+  const panel = builder.panel({name: 'Plots'});
+  const select1 = builder.plot({
+    title: 'Basic Plot',
+    independentVariable: '/plan/distance',
+    dependentVariables: ['/plan/cost']
+  });
+  builder.child(panel).child(select1);
+
+  const expected = {
+    Plots: {
+      name: 'Plots',
+      type: 'panel',
+      children: [
+        {
+          type: 'plot',
+          title: 'Basic Plot',
+          independentVariable: '/plan/distance',
+          dependentVariables: ['/plan/cost']
+        }
+      ]
     }
-  }
+  };
+
+  const actual = builder.getUI();
+  t.deepEqual(actual, expected, 'XVIZUIBuilder should match expectation');
+
+  validateUIBuilderOutput(actual);
 
   t.end();
 });


### PR DESCRIPTION
The declarative UI plot component has a single "independentVariable" and
multiple "dependentVariables".  In many places we forgot the "s".
That is not fixed with both the spec and the builder updated and tested.