### PR TITLE
Fully flesh out XVIZ stream metadata

### DIFF
--- a/docs/protocol-schema/session-protocol.md
+++ b/docs/protocol-schema/session-protocol.md
@@ -131,6 +131,11 @@ reconfiguration happens.
 | `units`              | `string`                          | For variable and time series data this lets the user know what kind of data they are looking at.                                                           |
 | `value_map`          | `optional<enum{ stream values }>` | A list of all of the values that will be sent on the stream. The indexes of the values are used to translate them into numeric values for plotting.        |
 | `style_info`         | `map<class_id, style>`            | Describes how the data should be rendered.                                                                                                                 |
+| `category`           | `enum{ category }`                | What kind of data is on this stream, see the matching type field for details.                                                                              |
+| `scalar_type`        | `enum{ scalar-types }`            | The kind of value for `time_series` or `variable`                                                                                                          |
+| `primitive_type`     | `enum{ primitive_types }`         | What is the exact primitive                                                                                                                                |
+| `ui_primitive_type`  | `enum{ ui_primitive_types }`      | The only valid type is "treetable" right now.                                                                                                              |
+| `annotation_type`    | `enum{ annotation_types }`        | The only valid type is "visual" right now.                                                                                                                 |
 
 Frames:
 
@@ -138,7 +143,34 @@ Frames:
 - `GEOGRAPHIC` - data in lat/lon/altitude
 - `VEHICLE_RELATIVE` - the data is relative to primary vehicle, with an optional additional
   transform
-- `DYNAMIC` -
+- `DYNAMIC` - name of a function which returns the needed transform at runtime
+
+Category:
+
+- `primitive`
+- `time_series`
+- `variable`
+- `annotation`
+- `future_instance`
+- `pose`
+- `ui_primitive`
+
+Scalar types:
+
+- `float`
+- `in32`
+- `string`
+- `bool`
+
+Primitive types:
+
+- `circle`
+- `image`
+- `point`
+- `polygon`
+- `polyline`
+- `stadium`
+- `text`
 
 ### Camera Info
 

--- a/modules/builder/src/builders/xviz-metadata-builder.js
+++ b/modules/builder/src/builders/xviz-metadata-builder.js
@@ -23,6 +23,7 @@ export default class XVIZMetadataBuilder {
     this.tmp_matrix_transform = null;
     this.tmp_pose_transform = null;
     this.tmp_log_info = {};
+    this.tmp_type = null;
     // TODO:
     // cameras
     // stream_aliases
@@ -81,7 +82,7 @@ export default class XVIZMetadataBuilder {
 
   // Used for validation in XVIZBuilder
   type(t) {
-    this.tmp_stream.type = t;
+    this.tmp_type = t;
     return this;
   }
 
@@ -156,6 +157,12 @@ export default class XVIZMetadataBuilder {
         streamData.transform = transform;
       }
 
+      if (streamData.category === 'primitive') {
+        streamData.primitive_type = this.tmp_type;
+      } else if (streamData.category === 'variable' || streamData.category === 'time_series') {
+        streamData.scalar_type = this.tmp_type;
+      }
+
       this.data.streams[this.streamId] = streamData;
     }
 
@@ -167,5 +174,6 @@ export default class XVIZMetadataBuilder {
     this.tmp_stream = {};
     this.tmp_matrix_transform = null;
     this.tmp_pose_transform = null;
+    this.tmp_type = null;
   }
 }

--- a/modules/schema/examples/session/metadata/complete.json
+++ b/modules/schema/examples/session/metadata/complete.json
@@ -3,8 +3,15 @@
   "streams": {
     "/velocity": {
       "units": "m",
+      "category": "time_series",
+      "scalar_type": "float"
+    },
+    "/data": {
+      "units": "m",
       "coordinate": "DYNAMIC",
-      "transform_callback": "map_base"
+      "transform_callback": "map_base",
+      "category": "primitive",
+      "primitive_type": "point"
     }
   },
   "cameras": {

--- a/modules/schema/examples/session/stream_metadata/stream_category_annotation_type.json
+++ b/modules/schema/examples/session/stream_metadata/stream_category_annotation_type.json
@@ -1,0 +1,4 @@
+{
+  "category": "annotation",
+  "annotation_type": "visual"
+}

--- a/modules/schema/examples/session/stream_metadata/stream_category_only.json
+++ b/modules/schema/examples/session/stream_metadata/stream_category_only.json
@@ -1,3 +1,3 @@
 {
-  "category": "variable"
+  "category": "pose"
 }

--- a/modules/schema/examples/session/stream_metadata/stream_category_primitive_type.json
+++ b/modules/schema/examples/session/stream_metadata/stream_category_primitive_type.json
@@ -4,7 +4,7 @@
     "fill_color": [25, 25, 25, 255]
   },
   "category": "primitive",
-  "type": "polygon",
+  "primitive_type": "polygon",
   "style_classes": [
     {
       "name": "fancy",

--- a/modules/schema/examples/session/stream_metadata/stream_category_scalar_type.json
+++ b/modules/schema/examples/session/stream_metadata/stream_category_scalar_type.json
@@ -1,0 +1,4 @@
+{
+  "category": "variable",
+  "scalar_type": "float"
+}

--- a/modules/schema/examples/session/stream_metadata/stream_category_ui_primitive_type.json
+++ b/modules/schema/examples/session/stream_metadata/stream_category_ui_primitive_type.json
@@ -1,0 +1,4 @@
+{
+  "category": "ui_primitive",
+  "ui_primitive_type": "treetable"
+}

--- a/modules/schema/invalid/session/stream_metadata/invalid_stream_primitive_type.json
+++ b/modules/schema/invalid/session/stream_metadata/invalid_stream_primitive_type.json
@@ -1,0 +1,4 @@
+{
+  "category": "primitive",
+  "primitive_type": "model"
+}

--- a/modules/schema/invalid/session/stream_metadata/invalid_stream_type.json
+++ b/modules/schema/invalid/session/stream_metadata/invalid_stream_type.json
@@ -1,4 +1,0 @@
-{
-  "category": "primitive", 
-  "type": "model"
-}

--- a/modules/schema/invalid/session/stream_metadata/invalid_stream_ui_primitive_type.json
+++ b/modules/schema/invalid/session/stream_metadata/invalid_stream_ui_primitive_type.json
@@ -1,0 +1,4 @@
+{
+  "category": "ui_primitive",
+  "ui_primitive_type": "model"
+}

--- a/modules/schema/invalid/session/stream_metadata/missin_primitive_type.json
+++ b/modules/schema/invalid/session/stream_metadata/missin_primitive_type.json
@@ -1,0 +1,3 @@
+{
+  "category": "primitive"
+}

--- a/modules/schema/invalid/session/stream_metadata/missing_annotation_type.json
+++ b/modules/schema/invalid/session/stream_metadata/missing_annotation_type.json
@@ -1,0 +1,3 @@
+{
+  "category": "annotation"
+}

--- a/modules/schema/invalid/session/stream_metadata/missing_scalar_type.json
+++ b/modules/schema/invalid/session/stream_metadata/missing_scalar_type.json
@@ -1,0 +1,3 @@
+{
+  "category": "time_series"
+}

--- a/modules/schema/invalid/session/stream_metadata/missing_ui_primitive_type.json
+++ b/modules/schema/invalid/session/stream_metadata/missing_ui_primitive_type.json
@@ -1,0 +1,3 @@
+{
+  "category": "ui_primitive"
+}

--- a/modules/schema/proto/v2/session.proto
+++ b/modules/schema/proto/v2/session.proto
@@ -15,7 +15,7 @@ package xviz.v2.session;
 message Start
 {
     option (xviz_json_schema) = "session/start";
-    
+
     string version = 1;
 
     string profile = 2;
@@ -34,14 +34,14 @@ message Start
         json = 1;
         binary = 2;
     }
-    
+
     MessageFormat message_format = 4;
 }
 
 
 message StateUpdate
 {
-    option (xviz_json_schema) = "session/state_update";    
+    option (xviz_json_schema) = "session/state_update";
 
     enum UpdateType
     {
@@ -75,7 +75,7 @@ message Reconfigure
 
 message Metadata
 {
-    option (xviz_json_schema) = "session/metadata";    
+    option (xviz_json_schema) = "session/metadata";
 
     string version = 1;
 
@@ -91,24 +91,38 @@ message Metadata
 
 message StreamMetadata
 {
-    option (xviz_json_schema) = "session/stream_metadata";    
+    option (xviz_json_schema) = "session/stream_metadata";
 
     string source = 1;
 
     string units = 2;
-    
+
+    // Type information
+
     enum Category
     {
         category_not_set = 0;
-        annotation = 1;
-        future_instance = 2;
-        pose = 3;
-        primitive = 4;
-        time_series = 5;
-        variable = 6;
+        primitive = 1;
+        time_series = 2;
+        variable = 3;
+        annotation = 4;
+        future_instance = 5;
+        pose = 6;
+        ui_primitive = 7;
     }
 
     Category category = 3;
+
+    enum ScalarType
+    {
+        scalar_type_not_set = 0;
+        float = 1;
+        in32 = 2;
+        string = 3;
+        bool = 4;
+    }
+
+    ScalarType scalar_type = 4;
 
     enum PrimitiveType
     {
@@ -121,13 +135,35 @@ message StreamMetadata
         stadium = 6;
         text = 7;
     }
-    
-    PrimitiveType type = 4;
 
-    style.StreamValue stream_style = 5;
+    PrimitiveType primitive_type = 5;
 
-    repeated style.Class style_classes = 6;
-    
+    enum UIPrimitiveType
+    {
+        ui_primitive_type_not_set = 0;
+        treetable = 1;
+    }
+
+    UIPrimitiveType ui_primitive_type = 6;
+
+    enum AnnotationType
+    {
+        annotation_type_not_set = 0;
+        visual = 1;
+    }
+
+    AnnotationType annotation_type = 7;
+
+
+    // Style information
+
+    style.StreamValue stream_style = 8;
+
+    repeated style.Class style_classes = 9;
+
+
+    // Coordinate information
+
     enum CoordinateType
     {
         NOT_SET = 0;
@@ -137,18 +173,18 @@ message StreamMetadata
         VEHICLE_RELATIVE = 4;
     }
 
-    CoordinateType coordinate = 7;
+    CoordinateType coordinate = 10;
 
     /// 4x4 matrix flattened into 16 elements
-    repeated double transform = 8;
+    repeated double transform = 11;
 
-    string transform_callback = 9;
+    string transform_callback = 12;
 }
 
 
 message CameraInfo
 {
-    option (xviz_json_schema) = "session/camera_info";    
+    option (xviz_json_schema) = "session/camera_info";
 
     string human_name = 1;
 

--- a/modules/schema/session/stream_metadata.schema.json
+++ b/modules/schema/session/stream_metadata.schema.json
@@ -23,11 +23,20 @@
         "future_instance",
         "pose",
         "primitive",
+        "ui_primitive",
         "time_series",
         "variable"
       ]
     },
-    "type": {
+    "scalar_type": {
+      "enum": [
+        "float",
+        "int32",
+        "bool",
+        "string"
+      ]
+    },
+    "primitive_type": {
       "enum": [
         "circle",
         "image",
@@ -36,6 +45,16 @@
         "polyline",
         "stadium",
         "text"
+      ]
+    },
+    "ui_primitive_type": {
+      "enum": [
+        "treetable"
+      ]
+    },
+    "annotation_type": {
+      "enum": [
+        "visual"
       ]
     },
     "stream_style": {
@@ -81,21 +100,49 @@
           "properties": {
             "category": {
               "enum": [
-                "future_instance",
-                "primitive"
+                "time_series",
+                "variable"
               ]
             }
           },
-          "required": ["type"]
+          "required": ["scalar_type"]
         },
         {
           "properties": {
             "category": {
               "enum": [
-                "annotation",
-                "pose",
-                "time_series",
-                "variable"
+                "future_instance",
+                "primitive"
+              ]
+            }
+          },
+          "required": ["primitive_type"]
+        },
+        {
+          "properties": {
+            "category": {
+              "enum": [
+                "ui_primitive"
+              ]
+            }
+          },
+          "required": ["ui_primitive_type"]
+        },
+        {
+          "properties": {
+            "category": {
+              "enum": [
+                "annotation"
+              ]
+            }
+          },
+          "required": ["annotation_type"]
+        },
+        {
+          "properties": {
+            "category": {
+              "enum": [
+                "pose"
               ]
             }
           }

--- a/modules/schema/src/proto-utils.js
+++ b/modules/schema/src/proto-utils.js
@@ -54,8 +54,8 @@ export function enumToIntField(values, fieldName, jsonObject) {
     const newValue = values[originalValue];
 
     if (newValue === undefined) {
-      const msg = `Error: ${fieldName} not present on object`;
-      throw msg;
+      const msg = `Error: field "${fieldName}" has unknown enum value "${originalValue}"`;
+      throw new Error(msg);
     }
 
     jsonObject[fieldName] = newValue;

--- a/test/modules/builder/builders/xviz-metadata-builder.spec.js
+++ b/test/modules/builder/builders/xviz-metadata-builder.spec.js
@@ -33,7 +33,7 @@ test.skip('XVIZMetadataBuilder#build-with-transformMatrix-array', t => {
     streams: {
       '/test/stream': {
         category: 'primitive',
-        type: 'circle',
+        primitive_type: 'circle',
         coordinate: 'VEHICLE_RELATIVE',
         transform: new Matrix4([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]]),
         stream_style: {
@@ -84,7 +84,7 @@ test.skip('XVIZMetadataBuilder#build-with-transformMatrix-matrix4', t => {
     streams: {
       '/test/stream': {
         category: 'primitive',
-        type: 'circle',
+        primitive_type: 'circle',
         coordinate: 'VEHICLE_RELATIVE',
         transform: new Matrix4([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [1, 2, 3, 1]])
       }
@@ -122,7 +122,7 @@ test('XVIZMetadataBuilder#build-with-pose', t => {
     streams: {
       '/test/stream': {
         category: 'primitive',
-        type: 'polygon',
+        primitive_type: 'polygon',
         transform: new Matrix4([1, 0, -0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1])
       }
     },
@@ -145,7 +145,8 @@ test('XVIZMetadataBuilder#multiple-streams', t => {
     .category('primitive')
     .type('polygon')
     .stream('/test-stream/2')
-    .category('variable');
+    .category('variable')
+    .type('float');
 
   const metadata = xb.getMetadata();
 
@@ -156,10 +157,11 @@ test('XVIZMetadataBuilder#multiple-streams', t => {
     streams: {
       '/test-stream/1': {
         category: 'primitive',
-        type: 'polygon'
+        primitive_type: 'polygon'
       },
       '/test-stream/2': {
-        category: 'variable'
+        category: 'variable',
+        scalar_type: 'float'
       }
     },
     log_info: {


### PR DESCRIPTION
We want to be able say exactly what data is on what stream so we can
inform the front end of the fact.  This properly sets up a two tiered
system where you define the category a field is in, like "primitive"
then say what exactly it is like "circle".

The one interesting choice here is that we use the "scalar_type" field
to represent the type of both "time_series" and "variable" data.