### PR TITLE
Specification for reconfigure message

### DIFF
--- a/docs/protocol-schema/declarative-ui.md
+++ b/docs/protocol-schema/declarative-ui.md
@@ -396,7 +396,7 @@ The Select components allows dynamically configuring the XVIZ transformation don
 client. The component displays a list of options populated by a XVIZ variable stream, and allows the
 user to select one of them. This also known as a "combobox" or "dropdown".
 
-When a new option is selected the client sends backend a message (TODO specify me) with the updated
+When a new option is selected the client sends backend a message reconfiguration with the updated
 value then:
 
 - The backend responds with an updated view of the world for the current time
@@ -420,6 +420,26 @@ value then:
 | **Interaction** | **Description**                                 |
 | --------------- | ----------------------------------------------- |
 | `onchange`      | Reconfigure the backend when the select changes |
+
+#### Resulting messages
+
+The reconfiguration message sent preforms an update to the configuration of the backend. Allow to
+for example to toggle on and off an expensive to compute and transmit feature.
+
+So for the examples below we would get a `reconfigure` message of the form:
+
+```
+{
+    "update_type": "delta",
+    "config_update": {
+        "system": {
+            "info": {
+                "type": "newvalue"
+            }
+        }
+    }
+}
+```
 
 #### JSON Example
 

--- a/docs/protocol-schema/session-protocol.md
+++ b/docs/protocol-schema/session-protocol.md
@@ -97,6 +97,23 @@ has just the single `/object/polygon` containing a
 }
 ```
 
+## Request Messages
+
+### Reconfigure (WARNING: unstable feature)
+
+Reconfigure messages allow for a client to change the configuration of a XVIZ server, affecting all
+future requests for data from the server. This in turn enables a client to enable or disable
+expensive to compute or transmit features.
+
+A typical source for reconfigure messages would be a user selecting a new value in a
+[declarative ui select component](/docs/protocol-schema/declarative-ui.md#select-warning-unstable-feature-).
+Which would send a `delta` reconfigure message to the server.
+
+| Name            | Type                   | Description                                       |
+| --------------- | ---------------------- | ------------------------------------------------- |
+| `update_type`   | `enum { full, delta }` | Whether we have a complete or incremental update. |
+| `config_update` | `object`               | A JSON patch or full configuration update.        |
+
 ## Core Types
 
 ### Stream Metadata

--- a/modules/schema/examples/session/reconfigure/delta.json
+++ b/modules/schema/examples/session/reconfigure/delta.json
@@ -1,0 +1,8 @@
+{
+  "update_type": "delta",
+  "config_update": {
+    "base": {
+      "subprop": "value"
+    }
+  }
+}

--- a/modules/schema/examples/session/reconfigure/full.json
+++ b/modules/schema/examples/session/reconfigure/full.json
@@ -1,0 +1,10 @@
+{
+  "update_type": "full",
+  "config_update": {
+    "base": {
+      "subprop": "value",
+      "otherprop": 5,
+      "array": [1, 2, 3]
+    }
+  }
+}

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "ajv": "^6.5.2",
     "ajv-cli": "^3.0.0",
+    "is": "^3.2.1",
     "jsonlint": "^1.6.3",
     "protobufjs": "~6.8.8",
     "walk": "^2.3.14"

--- a/modules/schema/proto/v2/session.proto
+++ b/modules/schema/proto/v2/session.proto
@@ -8,6 +8,8 @@ import "core.proto";
 import "style.proto";
 import "options.proto";
 
+import "google/protobuf/struct.proto";
+
 package xviz.v2.session;
 
 message Start
@@ -52,6 +54,24 @@ message StateUpdate
 
     repeated core.StreamSet updates = 2;
 }
+
+
+message Reconfigure
+{
+    option (xviz_json_schema) = "session/reconfigure";
+
+    enum UpdateType
+    {
+        not_set = 0;
+        delta = 1;
+        full = 2;
+    }
+
+    UpdateType update_type = 1;
+
+    google.protobuf.Struct config_update = 2;
+}
+
 
 message Metadata
 {

--- a/modules/schema/session/reconfigure.schema.json
+++ b/modules/schema/session/reconfigure.schema.json
@@ -1,0 +1,22 @@
+{
+  "id": "https://xviz.org/schema/session/reconfigure.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "XVIZ Reconfigure message",
+  "type": "object",
+  "properties": {
+    "update_type": {
+      "enum": [
+        "delta",
+        "full"
+      ]
+    },
+    "config_update": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "update_type",
+    "config_update"
+  ],
+  "additionalProperties": false
+}

--- a/modules/schema/src/data.js
+++ b/modules/schema/src/data.js
@@ -38,6 +38,7 @@ import primitivesStadiumSchemaJson from '../primitives/stadium.schema.json';
 import primitivesTextSchemaJson from '../primitives/text.schema.json';
 import sessionCameraInfoSchemaJson from '../session/camera_info.schema.json';
 import sessionMetadataSchemaJson from '../session/metadata.schema.json';
+import sessionReconfigureSchemaJson from '../session/reconfigure.schema.json';
 import sessionStartSchemaJson from '../session/start.schema.json';
 import sessionStateUpdateSchemaJson from '../session/state_update.schema.json';
 import sessionStreamMetadataSchemaJson from '../session/stream_metadata.schema.json';
@@ -87,6 +88,7 @@ export const SCHEMA_DATA = {
   'primitives/text.schema.json': primitivesTextSchemaJson,
   'session/camera_info.schema.json': sessionCameraInfoSchemaJson,
   'session/metadata.schema.json': sessionMetadataSchemaJson,
+  'session/reconfigure.schema.json': sessionReconfigureSchemaJson,
   'session/start.schema.json': sessionStartSchemaJson,
   'session/state_update.schema.json': sessionStateUpdateSchemaJson,
   'session/stream_metadata.schema.json': sessionStreamMetadataSchemaJson,

--- a/modules/schema/src/index.js
+++ b/modules/schema/src/index.js
@@ -12,3 +12,5 @@ export {default as XVIZValidator} from './validator';
 export {loadProtos, getXVIZProtoTypes, EXTENSION_PROPERTY} from './proto-validation';
 
 export {protoEnumsToInts, enumToIntField} from './proto-utils';
+
+export {StructEncode} from './proto-struct-wrapper';

--- a/modules/schema/src/proto-struct-wrapper.js
+++ b/modules/schema/src/proto-struct-wrapper.js
@@ -1,0 +1,172 @@
+// Add support well known type google.protobuf.Struct.  Which when
+// encountered by full protobuf implementation it gets transparently
+// turned in JSON and back.
+
+// Code from, only changes are conversion to ES6 from typescript
+// https://github.com/dcodeIO/protobuf.js/issues/839#issuecomment-401279631
+
+import {wrappers} from 'protobufjs';
+import * as is from 'is';
+
+export class StructEncode {
+  // seenObjects: Set<{}>;
+  // removeCircular: boolean;
+  // stringify?: boolean;
+
+  constructor(options) {
+    options = options || {};
+
+    this.seenObjects = new Set();
+    this.removeCircular = options.removeCircular === true;
+    this.stringify = options.stringify === true;
+  }
+
+  encodeStruct(obj) {
+    const convertedObject = {
+      fields: {}
+    };
+
+    this.seenObjects.add(obj);
+
+    for (const prop in obj) {
+      if (obj.hasOwnProperty(prop)) {
+        const value = obj[prop];
+
+        if (is.undefined(value)) {
+          continue; // eslint-disable-line no-continue
+        }
+
+        convertedObject.fields[prop] = this.encodeValue(value);
+      }
+    }
+
+    this.seenObjects.delete(obj);
+
+    return convertedObject;
+  }
+
+  encodeValue(value) {
+    let convertedValue;
+
+    if (is.null(value)) {
+      convertedValue = {
+        nullValue: 0
+      };
+    } else if (is.number(value)) {
+      convertedValue = {
+        numberValue: value
+      };
+    } else if (is.string(value)) {
+      convertedValue = {
+        stringValue: value
+      };
+    } else if (is.boolean(value)) {
+      convertedValue = {
+        boolValue: value
+      };
+      // Not supported in Node.js and not needed for our level of support
+      // } else if (Buffer.isBuffer(value)) {
+      //   convertedValue = {
+      //     blobValue: value
+      //   };
+    } else if (is.object(value)) {
+      if (this.seenObjects.has(value)) {
+        // Circular reference.
+        if (!this.removeCircular) {
+          throw new Error(
+            [
+              'This object contains a circular reference. To automatically',
+              'remove it, set the `removeCircular` option to true.'
+            ].join(' ')
+          );
+        }
+        convertedValue = {
+          stringValue: '[Circular]'
+        };
+      } else {
+        convertedValue = {
+          structValue: this.encodeStruct(value)
+        };
+      }
+    } else if (is.array(value)) {
+      convertedValue = {
+        listValue: {
+          values: value.map(this.encodeValue.bind(this))
+        }
+      };
+    } else {
+      if (!this.stringify) {
+        throw new Error(`Value of type ${typeof value} not recognized.`);
+      }
+
+      convertedValue = {
+        stringValue: String(value)
+      };
+    }
+
+    return convertedValue;
+  }
+}
+
+export class StructDecode {
+  static decodeValue(value) {
+    switch (value.kind) {
+      case 'structValue': {
+        return StructDecode.decodeStruct(value.structValue);
+      }
+
+      case 'nullValue': {
+        return null;
+      }
+
+      case 'listValue': {
+        return value.listValue.values.map(StructDecode.decodeValue);
+      }
+
+      default: {
+        return value[value.kind];
+      }
+    }
+  }
+
+  static decodeStruct(struct) {
+    const convertedObject = {};
+
+    for (const prop in struct.fields) {
+      if (struct.fields.hasOwnProperty(prop)) {
+        const value = struct.fields[prop];
+        convertedObject[prop] = StructDecode.decodeValue(value);
+      }
+    }
+
+    return convertedObject;
+  }
+}
+
+wrappers['.google.protobuf.Value'] = {
+  fromObject(object) {
+    if (object) {
+      return new StructEncode().encodeValue(object);
+    }
+
+    return this.fromObject(object);
+  },
+
+  toObject(message) {
+    return StructDecode.decodeValue(message);
+  }
+};
+
+wrappers['.google.protobuf.Struct'] = {
+  fromObject(object) {
+    if (object) {
+      return new StructEncode().encodeStruct(object);
+    }
+
+    return this.fromObject(object);
+  },
+
+  toObject(message) {
+    return StructDecode.decodeStruct(message);
+  }
+};

--- a/test/modules/schema/proto-validation.spec.js
+++ b/test/modules/schema/proto-validation.spec.js
@@ -103,8 +103,10 @@ function validateAgainstExample(t, validator, protoType, examplePath) {
     t.fail(`JSON failed proto verify, err: ${err} for: ${examplePath}, content: ${content}`);
   }
 
-  // Populate proto object with content
-  const serializedProtoData = protoType.encode(jsonExample).finish();
+  // Populate proto object with content, we do "fromObject" first
+  // so that the well known types will be handled
+  const protoObject = protoType.fromObject(jsonExample);
+  const serializedProtoData = protoType.encode(protoObject).finish();
   const protoData = protoType.decode(serializedProtoData);
 
   // Dump to Object

--- a/yarn.lock
+++ b/yarn.lock
@@ -5742,6 +5742,10 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+is@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"


### PR DESCRIPTION
This allows a client to adjust how a server transform the data it
sends in XVIZ format.

In order to make this happen I had to add support for the
google.protobuf.Struct well known type to protobuf.js.  The upside it
lets us basically embed JSON directly into protobuf for use cases like
configuration updates.  It also does it in a way that is faster or
more dense than raw text.