### PR TITLE
Create an explicit schema for XVIZ JSON envelope format

### DIFF
--- a/modules/schema/envelope.schema.json
+++ b/modules/schema/envelope.schema.json
@@ -1,0 +1,64 @@
+{
+  "id": "https://xviz.org/schema/envelope.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "XVIZ data envelope",
+  "type": "object",
+  "properties":  {
+    "type": {},
+    "data": {}
+  },
+  "anyOf": [
+    {
+      "properties":  {
+        "type": {
+          "type": "string",
+          "pattern": "^((?!xviz\/).)*$"
+        },
+        "data": {
+          "type": "object"
+        }
+      }
+    },
+    {
+      "properties":  {
+        "type": {
+          "enum": [
+            "xviz/start"
+          ]
+        },
+        "data": {
+          "$ref": "https://xviz.org/schema/session/start.json"
+        }
+      }
+    },
+    {
+      "properties":  {
+        "type": {
+          "enum": [
+            "xviz/metadata"
+          ]
+        },
+        "data": {
+          "$ref": "https://xviz.org/schema/session/metadata.json"
+        }
+      }
+    },
+    {
+      "properties":  {
+        "type": {
+          "enum": [
+            "xviz/state_update"
+          ]
+        },
+        "data": {
+          "$ref": "https://xviz.org/schema/session/state_update.json"
+        }
+      }
+    }
+  ],
+  "required": [
+    "type",
+    "data"
+  ],
+  "additionalProperties": false
+}

--- a/modules/schema/examples/envelope/metadata.json
+++ b/modules/schema/examples/envelope/metadata.json
@@ -1,0 +1,6 @@
+{
+  "type": "xviz/metadata",
+  "data": {
+    "version": "2.0.0"
+  }
+}

--- a/modules/schema/examples/envelope/start.json
+++ b/modules/schema/examples/envelope/start.json
@@ -1,0 +1,7 @@
+{
+  "type": "xviz/start",
+  "data": {
+    "version": "2.0.0",
+    "profile": "fast"
+  }
+}

--- a/modules/schema/examples/envelope/state_update.json
+++ b/modules/schema/examples/envelope/state_update.json
@@ -1,0 +1,20 @@
+{
+  "type": "xviz/state_update",
+  "data": {
+    "update_type": "incremental",
+    "updates": [
+      {
+        "timestamp": 1001.3,
+        "primitives": {
+          "/object/points": {
+            "points": [
+              {
+                "points": [9, 15, 3, 20, 13, 3, 20, 5, 3]
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/modules/schema/examples/envelope/third_party.json
+++ b/modules/schema/examples/envelope/third_party.json
@@ -1,0 +1,6 @@
+{
+  "type": "other/subtype",
+  "data": {
+    "any": "thing"
+  }
+}

--- a/modules/schema/invalid/envelope/invalid_content.json
+++ b/modules/schema/invalid/envelope/invalid_content.json
@@ -1,0 +1,6 @@
+{
+  "type": "xviz/metadata",
+  "data": {
+    "version": 2
+  }
+}

--- a/modules/schema/invalid/envelope/invalid_xviz_type.json
+++ b/modules/schema/invalid/envelope/invalid_xviz_type.json
@@ -1,0 +1,6 @@
+{
+  "type": "xviz/foo",
+  "data": {
+    "version": "2.0.0"
+  }
+}

--- a/modules/schema/src/data.js
+++ b/modules/schema/src/data.js
@@ -25,6 +25,7 @@ import declarativeUiComponentsTabularSchemaJson from '../declarative-ui/componen
 import declarativeUiComponentsTreetableSchemaJson from '../declarative-ui/components/treetable.schema.json';
 import declarativeUiComponentsVideoSchemaJson from '../declarative-ui/components/video.schema.json';
 import declarativeUiPanelSchemaJson from '../declarative-ui/panel.schema.json';
+import envelopeSchemaJson from '../envelope.schema.json';
 import mathMatrix3x3SchemaJson from '../math/matrix3x3.schema.json';
 import mathMatrix4x4SchemaJson from '../math/matrix4x4.schema.json';
 import mathPoint3dListSchemaJson from '../math/point3d_list.schema.json';
@@ -75,6 +76,7 @@ export const SCHEMA_DATA = {
   'declarative-ui/components/treetable.schema.json': declarativeUiComponentsTreetableSchemaJson,
   'declarative-ui/components/video.schema.json': declarativeUiComponentsVideoSchemaJson,
   'declarative-ui/panel.schema.json': declarativeUiPanelSchemaJson,
+  'envelope.schema.json': envelopeSchemaJson,
   'math/matrix3x3.schema.json': mathMatrix3x3SchemaJson,
   'math/matrix4x4.schema.json': mathMatrix4x4SchemaJson,
   'math/point3d_list.schema.json': mathPoint3dListSchemaJson,


### PR DESCRIPTION
This is the wrapper we put our types so you can mix them with our JSON
types in the same stream and tell them apart.  With this schema we can
now quickly check that a stream of XVIZ payloads are correct.