### PR TITLE
Re-organize XVIZ schema and declarative UI docs

### DIFF
--- a/docs/declarative-ui/components.md
+++ b/docs/declarative-ui/components.md
@@ -1,132 +1,6 @@
-# Declarative UI
+# Components
 
-## Overview
-
-The purpose of the XVIZ Declarative UI is to enable developers to create interactive visuals using
-configuration from a backend. The declarative UI system is designed to provide a simple and
-extensible UI description system so that application developers can control what data is created and
-independent of understanding the intricacies of a specific XVIZ client application.
-
-## Data Model
-
-Declarative UI data is a hierarchical structure of layout elements and components. Components make
-up the majority of visuals with layout elements primarily providing information about how to
-organize their contents and supplemental information about the contents.
-
-![Data Model](./images/declarative-ui-data-model.png)
-
-_UML diagram of the UI data model_
-
-![Full UI Skeleton](./images/full-ui-skeleton.png)
-
-_Example skeleton UI showing how the pieces fit together_
-
-## Layout Types
-
-Layout types describe the different ways the contents of a layout element can be arranged, for
-example vertically or horizontally. Currently supported arrangement types are:
-
-- Vertical (`vertical`)
-- Horizontal (`horizontal`)
-
-### Vertical Layout
-
-In a vertical layout, elements and components are stacked on top of each other. The formal type for
-the vertical layout is vertical. The diagram below shows a UI in which the panel and both containers
-have a vertical layout.
-
-![Vertical Layout](./images/vertical-layout.png)
-
-### Horizontal Layout
-
-In a horizontal layout, elements and components are placed next to each other. The formal type for
-the horizontal layout is horizontal.The diagram below shows a UI in which the panel and both
-containers have a horizontal layout.
-
-![Horizontal Layout](./images/horizontal-layout.png)
-
-## Layout Interaction Types
-
-Layout interactions describe the ways that a layout element can be manipulated by a user. Layout
-interactions are completely optional, so each layout element can have zero, one, or more layout
-interactions applied to it. Currently supported layout interactions include:
-
-- Drag to Reorder (`reorderable`)
-- Drag out (`dragout`)
-
-### Drag to Reorder
-
-When a layout element supports the drag to reorder interaction, it means that the elements inside of
-the layout element can be rearranged by clicking and dragging them. The formal type for drag to
-reorder is `reorderable`.
-
-### Drag Out
-
-When a layout element supports the drag out interaction, it means that the components (and only the
-components) can be moved outside of their layout element. A table, for example, could be clicked and
-dragged to free float inside the application outside of the panel that originally contained it.
-Components previously dragged out can be dragged back into the layout element that originally
-contained them. The formal type for drag out is `dragout`.
-
-## Component Interaction Types
-
-Component interactions describe the ways that a component can be manipulated by a user. Unlike
-layout interactions, component interactions are inherent to the components themselves. As an
-example, a user can sort a table by the values in its columns without declaring the table as
-sortable. Not all component interaction types apply to every component, so it is important to note
-which interactions a component supports by looking at the documentation for the individual component
-types. The currently supported component interactions:
-
-- Highlight on Hover
-- Copy
-- Sort
-- Filter
-- Details on Hover
-- Toggle Streams On/Off
-- Select Source
-- Video Settings Adjustment
-- Change element (`onchange`)
-
-The interactions supported by each component as well as how each interaction behaves and looks is
-described below in the details of each individual component.
-
-## Layout Elements
-
-Layout elements are different from components in that they do not directly consume XVIZ stream data.
-Layout elements provide information about how to arrange components as well as additional
-information about their contents.
-
-### Panels
-
-Panels are typically grouped together in tabs along the edge of an application. Panels group
-together related pieces of data at a high level. Panels provide a convenient way for a team to group
-all of their data together.
-
-_TODO: screentshot: panel from streetscape.gl demo app_
-
-| **Name**       | **Type**                       | **Description**                                                                                          |
-| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `name`         | `string`                       | The name of this panel, will be displayed at the top of the panel                                        |
-| `layout`       | `layout_type`                  | One of the supported layout types; defines how the elements inside of the panel should be arranged.      |
-| `interactions` | `list<interaction_type>`       | A list of all of the interactions supported by this panel.                                               |
-| `children`     | `list<component OR container>` | All of the components and containers inside of this panel and the order in which they should be rendered |
-
-### Containers
-
-Containers are used to group components together into logical groupings of information that should
-be displayed together. To some extent, they can be thought of as HTML `<div>`s. Components within
-the container will be rendered above any other containers that are nested inside of the container.
-
-_TODO: screentshot: panel with containers from streetscape.gl demo app_
-
-| **Name**       | **Type**                       | **Description**                                                                                          |
-| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `name`         | `string`                       | The name of this container, will be displayed at the top of the container                                |
-| `layout`       | `layout_type`                  | One of the supported layout types; defines how the elements inside of the panel should be arranged.      |
-| `interactions` | `list<interaction_type>`       | A list of all of the interactions supported by this panel.                                               |
-| `children`     | `list<component OR container>` | All of the components and containers inside of this panel and the order in which they should be rendered |
-
-## Components
+## Common Fields
 
 Component is the base type for all visual elements.
 
@@ -143,7 +17,7 @@ The valid values of `component_type`:
 - `video`
 - `select` (WARNING: Unstable feature)
 
-### Table
+## Table
 
 The Table element renders data similar to how data is presented in a traditional HTML table.
 
@@ -156,7 +30,7 @@ _TODO: screentshot: panel with table from streetscape.gl demo app_
 | `description`     | `string`    | A description of this element, displayed when hovering over the title.                                   |
 | `displayObjectId` | `boolean`   | Controls whether or not the object ID column, which is automatically added to TreeTables, is displayed.  |
 
-#### Supported Interactions
+### Supported Interactions
 
 | **Interaction**    | **Description**                                                                      |
 | ------------------ | ------------------------------------------------------------------------------------ |
@@ -165,9 +39,9 @@ _TODO: screentshot: panel with table from streetscape.gl demo app_
 | Sort               | Sort the table based on the contents of the columns                                  |
 | Filter             | Exclude rows based on their values in certain columns                                |
 
-#### JSON Example
+### JSON Example
 
-```
+```js
 {
   "components": [
     {
@@ -181,7 +55,7 @@ _TODO: screentshot: panel with table from streetscape.gl demo app_
 }
 ```
 
-#### YAML Example
+### YAML Example
 
 ```
 components:
@@ -192,7 +66,7 @@ components:
     type: table
 ```
 
-### Metric
+## Metric
 
 The Metric element renders time series data. A single metric element can render multiple streams of
 time series data on the same chart so that data can be easily compared.
@@ -205,15 +79,15 @@ _TODO: screenshot: streetscape.gl demo app showing drag-able sub-panels_
 | `title`       | `string`                 |                                                                                                         |
 | `description` | `string`                 | Displayed when hovering over the title                                                                  |
 
-#### Supported Interactions
+### Supported Interactions
 
 | **Interaction**  | **Description**                                                                                |
 | ---------------- | ---------------------------------------------------------------------------------------------- |
 | Details on Hover | When hovering over a metrics element, the current value of the metric at the location is shown |
 
-#### JSON Example
+### JSON Example
 
-```
+```js
 {
   "components": [
     {
@@ -226,7 +100,7 @@ _TODO: screenshot: streetscape.gl demo app showing drag-able sub-panels_
 }
 ```
 
-#### YAML Example
+### YAML Example
 
 ```
 components:
@@ -238,7 +112,7 @@ components:
       - /some_value/commanded
 ```
 
-### Plot
+## Plot
 
 The Plot component is used for showing one or more variables at once on screen. It has a standard
 mode where it shows a set of dependent variables as a function of an independent variable. In region
@@ -274,16 +148,16 @@ style these regions apply style information to the `x` stream.
 | `yMin`   | `stream_id` | The visible lower bound of the region on the Y axis, expected a floating point variable stream.                                 |
 | `yMax`   | `stream_id` | The visible upper bound of the region on the Y axis, , expected a floating point variable stream.                               |
 
-#### Supported Interactions
+### Supported Interactions
 
 | **Interaction**       | **Description**                                                                                                 |
 | --------------------- | --------------------------------------------------------------------------------------------------------------- |
 | Details on Hover      | When hovering over the plot, the exact value of every stream at the point being hovered over will be displayed. |
 | Toggle Streams On/Off | Below the plot a list of streams is shown, clicking on the streams will toggle displaying them on the plot      |
 
-#### JSON Example
+### JSON Example
 
-```
+```js
 {
   "components": [
     {
@@ -297,7 +171,7 @@ style these regions apply style information to the `x` stream.
 }
 ```
 
-#### YAML Example
+### YAML Example
 
 ```
 components:
@@ -310,7 +184,7 @@ components:
     - /some/second_other_stream
 ```
 
-### Video
+## Video
 
 The Video element is used to display streams of video data. A single video element can support
 multiple streams of video, however not all streams may be viewed at the same time. To view multiple
@@ -322,16 +196,16 @@ _TODO: screenshot: streetscape.gl demo app showing the video element_
 | --------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `cameras` | `list<string>` | A list of the streams of video that can be rendered by this element. Only [[cameras listed - TODO link to camera metadata] |
 
-#### Supported Interactions
+### Supported Interactions
 
 | **Interaction**           | **Description**                                                                                                                               |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Select source             | Using a dropdown overlayed on the video, a user can select which video to show.                                                               |
 | Video settings adjustment | A user can adjust video settings such as saturation, brightness, and contrast from the settings menu that is overlaid on the video component. |
 
-#### JSON Example
+### JSON Example
 
-```
+```js
 {
   "components": [
     {
@@ -346,7 +220,7 @@ _TODO: screenshot: streetscape.gl demo app showing the video element_
 }
 ```
 
-#### YAML Example
+### YAML Example
 
 ```
 components:
@@ -357,7 +231,7 @@ components:
       - rear-port-roof-camera
 ```
 
-### TreeTable
+## TreeTable
 
 The TreeTable represents data in a way similar to that of a file system explorer window. The data is
 hierarchical with common fields at each node, some fields being empty depending on where the node
@@ -376,7 +250,7 @@ _TODO: screenshot: streetscape.gl demo app showing treetable data_
 | `description`       | `string`    | A description of this component, displayed when hovering over the title.             |
 | `display_object_id` | `boolean`   | Whether or not to display the object ID column                                       |
 
-#### Supported Interactions
+### Supported Interactions
 
 | **Interaction**    | **Description**                                                                      |
 | ------------------ | ------------------------------------------------------------------------------------ |
@@ -385,9 +259,9 @@ _TODO: screenshot: streetscape.gl demo app showing treetable data_
 | Sort               | Sort the table based on the contents of the columns                                  |
 | Filter             | Exclude rows based on their values in certain columns                                |
 
-#### JSON Example
+### JSON Example
 
-```
+```js
 {
   "components": [
     {
@@ -401,7 +275,7 @@ _TODO: screenshot: streetscape.gl demo app showing treetable data_
 }
 ```
 
-#### YAML Example
+### YAML Example
 
 ```
 components:
@@ -412,7 +286,7 @@ components:
     type: treetable
 ```
 
-### Select (WARNING: Unstable feature)
+## Select (WARNING: Unstable feature)
 
 The Select components allows dynamically configuring the XVIZ transformation done on data sent to
 client. The component displays a list of options populated by a XVIZ variable stream, and allows the
@@ -437,13 +311,13 @@ value then:
 | -------- | -------- | ---------------------------------------------------------- |
 | `target` | `string` | A JSON pointer (RFC 6901) that describes the key to update |
 
-#### Supported Interactions
+### Supported Interactions
 
 | **Interaction** | **Description**                                 |
 | --------------- | ----------------------------------------------- |
 | `onchange`      | Reconfigure the backend when the select changes |
 
-#### Resulting messages
+### Resulting messages
 
 The reconfiguration message sent preforms an update to the configuration of the backend. Allow to
 for example to toggle on and off an expensive to compute and transmit feature.
@@ -463,9 +337,9 @@ So for the examples below we would get a `reconfigure` message of the form:
 }
 ```
 
-#### JSON Example
+### JSON Example
 
-```
+```js
 {
   "components": [
     {
@@ -481,7 +355,7 @@ So for the examples below we would get a `reconfigure` message of the form:
 }
 ```
 
-#### YAML Example
+### YAML Example
 
 ```
 components:
@@ -497,9 +371,9 @@ components:
 
 Below is a complete example of what a panel definition would look like
 
-### JSON Example
+## JSON Example
 
-```
+```js
 {
   "type": "panel",
   "layout": "vertical",
@@ -576,7 +450,7 @@ Below is a complete example of what a panel definition would look like
 }
 ```
 
-### YAML Example
+## YAML Example
 
 ```
 components:

--- a/docs/declarative-ui/interactions.md
+++ b/docs/declarative-ui/interactions.md
@@ -1,0 +1,46 @@
+# Interaction Types
+
+## Layout Interaction Types
+
+Layout interactions describe the ways that a layout element can be manipulated by a user. Layout
+interactions are completely optional, so each layout element can have zero, one, or more layout
+interactions applied to it. Currently supported layout interactions include:
+
+- Drag to Reorder (`reorderable`)
+- Drag out (`dragout`)
+
+### Drag to Reorder
+
+When a layout element supports the drag to reorder interaction, it means that the elements inside of
+the layout element can be rearranged by clicking and dragging them. The formal type for drag to
+reorder is `reorderable`.
+
+### Drag Out
+
+When a layout element supports the drag out interaction, it means that the components (and only the
+components) can be moved outside of their layout element. A table, for example, could be clicked and
+dragged to free float inside the application outside of the panel that originally contained it.
+Components previously dragged out can be dragged back into the layout element that originally
+contained them. The formal type for drag out is `dragout`.
+
+## Component Interaction Types
+
+Component interactions describe the ways that a component can be manipulated by a user. Unlike
+layout interactions, component interactions are inherent to the components themselves. As an
+example, a user can sort a table by the values in its columns without declaring the table as
+sortable. Not all component interaction types apply to every component, so it is important to note
+which interactions a component supports by looking at the documentation for the individual component
+types. The currently supported component interactions:
+
+- Highlight on Hover
+- Copy
+- Sort
+- Filter
+- Details on Hover
+- Toggle Streams On/Off
+- Select Source
+- Video Settings Adjustment
+- Change element (`onchange`)
+
+The interactions supported by each component as well as how each interaction behaves and looks is
+described below in the details of each individual component.

--- a/docs/declarative-ui/layout-elements.md
+++ b/docs/declarative-ui/layout-elements.md
@@ -1,0 +1,35 @@
+# Layout Elements
+
+Layout elements are different from components in that they do not directly consume XVIZ stream data.
+Layout elements provide information about how to arrange components as well as additional
+information about their contents.
+
+## Panels
+
+Panels are typically grouped together in tabs along the edge of an application. Panels group
+together related pieces of data at a high level. Panels provide a convenient way for a team to group
+all of their data together.
+
+_TODO: screentshot: panel from streetscape.gl demo app_
+
+| **Name**       | **Type**                       | **Description**                                                                                          |
+| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `name`         | `string`                       | The name of this panel, will be displayed at the top of the panel                                        |
+| `layout`       | `layout_type`                  | One of the supported layout types; defines how the elements inside of the panel should be arranged.      |
+| `interactions` | `list<interaction_type>`       | A list of all of the interactions supported by this panel.                                               |
+| `children`     | `list<component OR container>` | All of the components and containers inside of this panel and the order in which they should be rendered |
+
+## Containers
+
+Containers are used to group components together into logical groupings of information that should
+be displayed together. To some extent, they can be thought of as HTML `<div>`s. Components within
+the container will be rendered above any other containers that are nested inside of the container.
+
+_TODO: screentshot: panel with containers from streetscape.gl demo app_
+
+| **Name**       | **Type**                       | **Description**                                                                                          |
+| -------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `name`         | `string`                       | The name of this container, will be displayed at the top of the container                                |
+| `layout`       | `layout_type`                  | One of the supported layout types; defines how the elements inside of the panel should be arranged.      |
+| `interactions` | `list<interaction_type>`       | A list of all of the interactions supported by this panel.                                               |
+| `children`     | `list<component OR container>` | All of the components and containers inside of this panel and the order in which they should be rendered |

--- a/docs/declarative-ui/layout-types.md
+++ b/docs/declarative-ui/layout-types.md
@@ -1,0 +1,23 @@
+# Layout Types
+
+Layout types describe the different ways the contents of a layout element can be arranged, for
+example vertically or horizontally. Currently supported arrangement types are:
+
+- Vertical (`vertical`)
+- Horizontal (`horizontal`)
+
+## Vertical Layout
+
+In a vertical layout, elements and components are stacked on top of each other. The formal type for
+the vertical layout is vertical. The diagram below shows a UI in which the panel and both containers
+have a vertical layout.
+
+![Vertical Layout](./images/vertical-layout.png)
+
+## Horizontal Layout
+
+In a horizontal layout, elements and components are placed next to each other. The formal type for
+the horizontal layout is horizontal.The diagram below shows a UI in which the panel and both
+containers have a horizontal layout.
+
+![Horizontal Layout](./images/horizontal-layout.png)

--- a/docs/declarative-ui/overview.md
+++ b/docs/declarative-ui/overview.md
@@ -1,0 +1,22 @@
+# Declarative UI
+
+## Overview
+
+The purpose of the XVIZ Declarative UI is to enable developers to create interactive visuals using
+configuration from a backend. The declarative UI system is designed to provide a simple and
+extensible UI description system so that application developers can control what data is created and
+independent of understanding the intricacies of a specific XVIZ client application.
+
+## Data Model
+
+Declarative UI data is a hierarchical structure of layout elements and components. Components make
+up the majority of visuals with layout elements primarily providing information about how to
+organize their contents and supplemental information about the contents.
+
+![Data Model](./images/declarative-ui-data-model.png)
+
+_UML diagram of the UI data model_
+
+![Full UI Skeleton](./images/full-ui-skeleton.png)
+
+_Example skeleton UI showing how the pieces fit together_

--- a/docs/protocol-schema/core-types.md
+++ b/docs/protocol-schema/core-types.md
@@ -1,93 +1,6 @@
-# XVIZ v2.0.0 Protocol Specification
+# XVIZ Core Types
 
-## Introduction
-
-XVIZ is an abstract visual world state description format that can be updated both incrementally and
-with complete snapshots. It is designed to separate the reduction of large complex data streams into
-a logical visual hierarchy from the building of rich applications to view that data.
-
-## Data Model
-
-Here is a map of all the objects in a typical XVIZ world state:
-
-### Streams and World State
-
-XVIZ divides the state of the world into a set of streams. This allows user to quickly explore and
-filter the visual world to suit their use case. Each stream changes over time atomically. The world
-state represents a complete set of all the latest stream states for a particular time.
-
-### Primitives and Objects
-
-The base types of XVIZ are individual elements of data: primitives, variables and time series.
-
-- **Primitives** are abstract geometries.
-- **Variables** are arrays of data (often over time).
-- **Time series** are individual samples of a larger series.
-
-These individual elements have a common semantics meaning, which is captured by the collection they
-are contained within, the stream.
-
-As an example, the stream `/object/shape` would contain all primitive shapes, while /object/velocity
-would contain the numeric value for the objects' velocities.
-
-Since the representation for an object is split across streams, XVIZ base types can have an ID which
-will be used to maintain the relationship of the data. In the example above, the /shape stream would
-transmit the object’s shape information, while the /velocity stream would transmit the object’s
-velocity information. These streams are separated for ease of parsing and improved data
-compression - for example, object shapes may only need to be updated once per second, whereas
-velocities might be more useful updated 10 times per second.
-
-### Poses
-
-A core part of XVIZ is knowing the location of the vehicle(s) so they can be displayed relative to
-the other data. This defines the location of the vehicle from it's own arbitrary frame, along with
-it's location in latitude, longitude, form.
-
-| Name          | Type              | Description                                                  |
-| ------------- | ----------------- | ------------------------------------------------------------ |
-| `timestamp`   | `float`           | The vehicle/log transmission_time associated with this data. |
-| `mapOrigin`   | `map_origin`      | Uniquely identifies an object for all time.                  |
-| `position`    | `array<float>(3)` | x, y, z position in meters                                   |
-| `orientation` | `array<float>(3)` | roll, pitch, yaw angle in radians                            |
-
-The `map_origin` object describes a location in geographic coordinates and altitude:
-
-| Name        | Type    | Description                                      |
-| ----------- | ------- | ------------------------------------------------ |
-| `longitude` | `float` | The east-west geographic coordinate in degrees   |
-| `latitude`  | `float` | The north-south geographic coordinate in degrees |
-| `altitude`  | `float` | The altitude above sea level in meters           |
-
-### Styles
-
-Similar to CSS each primitive can have one or more classes, each of which can have associated style
-information. This allows the styling information to be sent out of band with the main data flows,
-and only once. Learn more in the
-[style specification](/docs/protocol-schema/style-specification.md).
-
-### Annotations
-
-Annotations are themselves sent as XVIZ streams, but provide strictly supplemental information for
-another stream. Annotations are used when one team needs to append additional visual information to
-objects other than their own.
-
-## Implementations
-
-XVIZ is used when talking to a server or reading data exported and stored on disk. To learn more
-about them see:
-
-- [Session Protocol](/docs/protocol-schema/session-protocol.md)
-- ETL - current unspecified
-
-> Need XVIZ OSS specification for XVIZ 2.0 ETL format
-
-Both of those methods can use either of the two public XVIZ protocol implementations to encode the
-types described below:
-
-- [JSON protocol](/docs/protocol-formats/json-protocol.md) - a straight forward mapping of above
-  types into JSON
-- [Binary protocol](/docs/protocol-formats/binary-protocol.md) - a Hybrid JSON binary protocol
-  designed for larger data sets and faster performance
+## Basic Types
 
 ## ID Types
 
@@ -104,20 +17,24 @@ listed here so that they can be defined only once.
 | `treetable_node_id`   | `uint32`        | Uniquely identifies a node in a tree table and acts as a pointer to the node                              |
 | `type_id`             | `variable_type` | An enum of bool, integer, double, and string types                                                        |
 
-## Style
+### Point3D
 
-Style information describes the appearance of primitives. Color information can be directly attached
-to primitives but styles pertaining to many or all primitives should be pulled out into style
-messages. This reduces the amount of data sent across the network and improves maintainability.
+The Point3D type is used to represent coordinates. Note that it does not use fields x, y, and z but
+rather has an array of three floating point values with the indexes 0, 1, and 2 corresponding to x,
+y, and z respectively.
 
-Details in separate [style specification](/docs/protocol-schema/style-specification.md).
+| Name          | Type              | Description                 |
+| ------------- | ----------------- | --------------------------- |
+| `coordinates` | `array<float>(3)` | What kind of object is this |
 
-| Name     | Type                              | Description                                 |
-| -------- | --------------------------------- | ------------------------------------------- |
-| `fields` | `map<style_field, value_variant>` | The variant for HIDL will be a custom type. |
+### Flat Arrays
 
-**value_variant** - the most efficient variant type we can make represents, string, rgba_color,
-float, boolean
+For faster loading directly in memory buffers where you see `list<Point3d>` a flat list of numbers
+can be supplied. In those cases that list must be a multiple of 3, where each 3 elements is the
+`(x,y,z)` tuple that makes up a 3D point.
+
+The same is true of `list<color>`, instead the list must be a multiple of 4, where each element is
+the `(r, g, b, a)` color tuple.
 
 ## Stream Set
 
@@ -127,11 +44,11 @@ a single system frame. This is what an XVIZ extractor produces.
 | Name            | Type                                 | Description                                                                                                                 |
 | --------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `timestamp`     | `timestamp`                          | The vehicle/log transmission_time associated with this data.                                                                |
-| `primitives`    | `map<stream_id, primitive_state>`    | Streams containing list of primitives.                                                                                      |
-| `ui_primitives` | `map<stream_id, ui_primitive_state>` | Streams containing list of UI specific primitives.                                                                          |
 | `poses`         | `map<stream_id, pose>`               | Related vehicle poses                                                                                                       |
-| `time_series`   | `list<time_series_state>`            |                                                                                                                             |
+| `primitives`    | `map<stream_id, primitive_state>`    | Streams containing list of primitives.                                                                                      |
 | `future_states` | `map<stream_id, future_instances>`   | Streams containing This represents a collection of primitives at different timestamps, for the current stream set timestamp |
+| `ui_primitives` | `map<stream_id, ui_primitive_state>` | Streams containing list of UI specific primitives.                                                                          |
+| `time_series`   | `list<time_series_state>`            |                                                                                                                             |
 | `variables`     | `map<stream_id, variable_state>`     | Streams containing list of values.                                                                                          |
 | `annotations`   | `map<stream_id, annotation_state>`   | Streams containing annotations                                                                                              |
 
@@ -159,6 +76,27 @@ This is what a full stream set would look like populated with a basic example of
 }
 ```
 
+## Pose
+
+A core part of XVIZ is knowing the location of the vehicle(s) so they can be displayed relative to
+the other data. This defines the location of the vehicle from it's own arbitrary frame, along with
+it's location in latitude, longitude, form.
+
+| Name          | Type              | Description                                                  |
+| ------------- | ----------------- | ------------------------------------------------------------ |
+| `timestamp`   | `float`           | The vehicle/log transmission_time associated with this data. |
+| `mapOrigin`   | `map_origin`      | Uniquely identifies an object for all time.                  |
+| `position`    | `array<float>(3)` | x, y, z position in meters                                   |
+| `orientation` | `array<float>(3)` | roll, pitch, yaw angle in radians                            |
+
+The `map_origin` object describes a location in geographic coordinates and altitude:
+
+| Name        | Type    | Description                                      |
+| ----------- | ------- | ------------------------------------------------ |
+| `longitude` | `float` | The east-west geographic coordinate in degrees   |
+| `latitude`  | `float` | The north-south geographic coordinate in degrees |
+| `altitude`  | `float` | The altitude above sea level in meters           |
+
 ## Primitive State
 
 This holds a lists of primitives of each type XVIZ supports. It's used by higher level to map
@@ -175,6 +113,10 @@ streams, `stream_set` or future points in time, `future_instances` to applicable
 | `points`    | `list<points>`    | points to draw    |
 | `stadiums`  | `list<stadiums>`  | stadiums to draw  |
 | `images`    | `list<images>`    | images to draw    |
+
+Go here to learn more about [geometry primitives](/docs/protocol-schema/geometry-primitives.md).
+
+Example:
 
 ```js
 {
@@ -193,6 +135,10 @@ This holds a lists of UI primitives XVIZ. It's used by higher level to map strea
 | Name        | Type        | Description                   |
 | ----------- | ----------- | ----------------------------- |
 | `treetable` | `treetable` | table/tree to display in a UI |
+
+Go here to learn more about [panel primitives](/docs/protocol-schema/panel-specification.md).
+
+Example:
 
 ```js
 {
@@ -251,28 +197,6 @@ instant. These are not for normal time ordered primitives.
 }
 ```
 
-## Variable State
-
-Maps a stream like `/constraints` to a single or multiple item list of variables. Multiple items
-indicate each object refers to a different variable.
-
-| Name        | Type             | Description          |
-| ----------- | ---------------- | -------------------- |
-| `variables` | `list<variable>` | Variables to display |
-
-```js
-{
-    "variables": [
-        {
-            "values":
-            {
-                "doubles": [1001.3, 1002.3, 1003.3]
-            }
-        }
-    ]
-}
-```
-
 ## Time Series State
 
 This models a set of values that changes each time a data is transformed. These are used to provide
@@ -304,57 +228,25 @@ Here is an example `time_series_state` for a system producing multiple values at
 }
 ```
 
-## Point3D
+## Variable State
 
-The Point3D type is used to represent coordinates. Note that it does not use fields x, y, and z but
-rather has an array of three floating point values with the indexes 0, 1, and 2 corresponding to x,
-y, and z respectively.
+Maps a stream like `/constraints` to a single or multiple item list of variables. Multiple items
+indicate each object refers to a different variable.
 
-| Name          | Type              | Description                 |
-| ------------- | ----------------- | --------------------------- |
-| `coordinates` | `array<float>(3)` | What kind of object is this |
-
-## Base Primitive
-
-Primitives are the most basic units of rendering data sent across the network. Every primitives has
-all the following fields:
-
-| Name            | Type                  | Description                                    |
-| --------------- | --------------------- | ---------------------------------------------- |
-| `object_id`     | `optional<object_id>` | Which object is this primitive associated with |
-| `inline_style`  | `optional<style>`     | Optional inline style                          |
-| `style_classes` | `list<class_id>`      | Semantic/visualize classes.                    |
-
-To see all the primitives see:
-
-- [Geometry Primitives](/docs/protocol-schema/geometry-primitives.md)
-- [Panel Primitives](/docs/protocol-schema/panel-specification.md)
-
-As an example in JSON of a `point` primitive using style classes:
+| Name        | Type             | Description          |
+| ----------- | ---------------- | -------------------- |
+| `variables` | `list<variable>` | Variables to display |
 
 ```js
 {
-    "base": {
-      "object_id": "178beda89169420cbb876c14acdba7f8",
-      "classes": ["car", "important"]
-    },
-    "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
-}
-```
-
-You can do the same with inline styles but it is much less efficient to send the same styling
-information for each object over and over. Here is what it looks like to use an inline style form:
-
-```js
-{
-    "base": {
-      "object_id": "178beda89169420cbb876c14acdba7f8",
-      "style": {
-          "fill_color": "#FF0000",
-          "stroke_color": "#000080"
-      }
-    },
-    "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
+    "variables": [
+        {
+            "values":
+            {
+                "doubles": [1001.3, 1002.3, 1003.3]
+            }
+        }
+    ]
 }
 ```
 
@@ -399,6 +291,15 @@ containing the above variables would look like:
     }
 }
 ```
+
+## Annotation State
+
+Maps a stream like `/annotations` to a single or multiple item list of variables. Multiple items
+indicate each object refers to a different variable.
+
+| Name          | Type               | Description          |
+| ------------- | ------------------ | -------------------- |
+| `annotations` | `list<annotation>` | Variables to display |
 
 ## Annotations
 

--- a/docs/protocol-schema/geometry-primitives.md
+++ b/docs/protocol-schema/geometry-primitives.md
@@ -1,6 +1,7 @@
 # XVIZ Primitive Specification
 
-The geometry primitives currently supported in XVIZ are:
+Primitives are the most basic units of rendering data. The geometry primitives currently supported
+in XVIZ are:
 
 - `point`
 - `polygon`
@@ -10,14 +11,49 @@ The geometry primitives currently supported in XVIZ are:
 - `text`
 - `image`
 
-## Flat Arrays
+## Base Field
 
-For faster loading directly in memory buffers where you see `list<Point3d>` a flat list of numbers
-can be supplied. In those cases that list must be a multiple of 3, where each 3 elements is the
-`(x,y,z)` tuple that makes up a 3D point.
+Every primitive in XVIZ has an optional base object which contains fields that are common to all
+objects. These fields let you associated data with an object or applying styling to the object.
 
-The same is true of `list<color>`, instead the list must be a multiple of 4, where each element is
-the `(r, g, b, a)` color tuple.
+Fields of the base object:
+
+| Name            | Type                  | Description                                    |
+| --------------- | --------------------- | ---------------------------------------------- |
+| `object_id`     | `optional<object_id>` | Which object is this primitive associated with |
+| `inline_style`  | `optional<style>`     | Optional inline style                          |
+| `style_classes` | `list<class_id>`      | Semantic/visualize classes.                    |
+
+## Styling
+
+A major use of the base object is to style a primitive. As an example in JSON of a `point` primitive
+using style classes:
+
+```js
+{
+    "base": {
+      "object_id": "178beda89169420cbb876c14acdba7f8",
+      "classes": ["car", "important"]
+    },
+    "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
+}
+```
+
+You can do the same with inline styles but it is much less efficient to send the same styling
+information for each object over and over. Here is what it looks like to use an inline style form:
+
+```js
+{
+    "base": {
+      "object_id": "178beda89169420cbb876c14acdba7f8",
+      "style": {
+          "fill_color": "#FF0000",
+          "stroke_color": "#000080"
+      }
+    },
+    "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
+}
+```
 
 ## Point Primitive
 
@@ -31,7 +67,7 @@ point cloud. If there is more than one vertex in the vertices field then it is a
 
 Example:
 
-```
+```js
 {
     "points": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
@@ -47,7 +83,7 @@ The polygon primitive is used to draw any closed shape.
 
 JSON example using style class for styling:
 
-```
+```js
 {
     "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
@@ -63,7 +99,7 @@ The polyline primitive is used to draw any polygonal chain.
 
 JSON example using style class for styling:
 
-```
+```js
 {
     "vertices": [[9, 15, 3], [20, 13, 3], [20, 5, 3]]
 }
@@ -80,7 +116,7 @@ The circle primitive is used to draw circles and rings, it’s center lines up w
 
 Example:
 
-```
+```js
 {
     "center": [9, 15, 3],
     "radius_m": 2.5
@@ -100,7 +136,7 @@ closest that XVIZ has to support for 3D capsule shapes.
 
 Example:
 
-```
+```js
 {
     "start": [9, 15, 3],
     "end": [20, 13, 3],
@@ -120,7 +156,7 @@ the top left corner of the text.
 
 Example:
 
-```
+```js
 {
     "position": [9, 15, 3],
     "text": "Location of interest"
@@ -141,7 +177,7 @@ The image primitive is used to render existing graphics.
 This is a pure JSON example, for efficiency reasons you would normally use the binary protocol which
 stores the raw image directly instead of needing to base64 encode it.
 
-```
+```js
 {
     "position": [9, 15, 3],
     "data": "/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=",

--- a/docs/protocol-schema/introduction.md
+++ b/docs/protocol-schema/introduction.md
@@ -1,0 +1,75 @@
+# XVIZ v2.0.0 Protocol Specification
+
+## Overview
+
+XVIZ is an abstract visual world state description format that can be updated both incrementally and
+with complete snapshots. It is designed to separate the reduction of large complex data streams into
+a logical visual hierarchy from the building of rich applications to view that data.
+
+## Data Model
+
+Here is a map of all the objects in a typical XVIZ world state:
+
+### Streams and World State
+
+XVIZ divides the state of the world into a set of streams. This allows user to quickly explore and
+filter the visual world to suit their use case. Each stream changes over time atomically. The world
+state represents a complete set of all the latest stream states for a particular time.
+
+### Primitives and Objects
+
+The base types of XVIZ are individual elements of data: primitives, variables and time series.
+
+- **Primitives** are abstract geometries.
+- **Variables** are arrays of data (often over time).
+- **Time series** are individual samples of a larger series.
+
+These individual elements have a common semantics meaning, which is captured by the collection they
+are contained within, the stream.
+
+As an example, the stream `/object/shape` would contain all primitive shapes, while /object/velocity
+would contain the numeric value for the objects' velocities.
+
+Since the representation for an object is split across streams, XVIZ base types can have an ID which
+will be used to maintain the relationship of the data. In the example above, the /shape stream would
+transmit the object’s shape information, while the /velocity stream would transmit the object’s
+velocity information. These streams are separated for ease of parsing and improved data
+compression - for example, object shapes may only need to be updated once per second, whereas
+velocities might be more useful updated 10 times per second.
+
+### Poses
+
+A core part of XVIZ is knowing the location of the vehicle(s) so they can be displayed relative to
+the other data. This defines the location of the vehicle from it's own arbitrary frame, along with
+it's location in latitude, longitude, form.
+
+### Styles
+
+Similar to CSS each primitive can have one or more classes, each of which can have associated style
+information. This allows the styling information to be sent out of band with the main data flows,
+and only once. In addition, just like in HTML and CSS, styling information can be sent inline for
+each object. Learn more in the [style specification](/docs/protocol-schema/style-specification.md).
+
+### Annotations
+
+Annotations are themselves sent as XVIZ streams, but provide strictly supplemental information for
+another stream. Annotations are used when one team needs to append additional visual information to
+objects other than their own.
+
+## Implementations
+
+XVIZ is used when talking to a server or reading data exported and stored on disk. To learn more
+about them see:
+
+- [Session Protocol](/docs/protocol-schema/session-protocol.md)
+- ETL - current unspecified
+
+> Need XVIZ OSS specification for XVIZ 2.0 ETL format
+
+Both of those methods can use either of the two public XVIZ protocol implementations to encode the
+types described below:
+
+- [JSON protocol](/docs/protocol-formats/json-protocol.md) - a straight forward mapping of above
+  types into JSON
+- [Binary protocol](/docs/protocol-formats/binary-protocol.md) - a Hybrid JSON binary protocol
+  designed for larger data sets and faster performance

--- a/docs/protocol-schema/style-specification.md
+++ b/docs/protocol-schema/style-specification.md
@@ -71,7 +71,7 @@ Here is an example of metadata with style classes defined for a stream '/object/
 
 ## Stream Styling
 
-Stream styling allows you to define all the properties that an Object my use, but also includes
+Stream styling allows you to define all the properties that an Object may use, but also includes
 additional properties that effectively act as toggles for rendering. These properties allow for some
 performance advantage in the rendering pipeline when set to 'false'.
 

--- a/website/src/mdRoutes.js
+++ b/website/src/mdRoutes.js
@@ -36,6 +36,7 @@ export default [
           }
         ]
       },
+
       {
         name: "Developer's Guide",
         children: [
@@ -81,12 +82,43 @@ export default [
           }
         ]
       },
+
+      {
+        name: 'Declarative UI',
+        children: [
+          {
+            name: 'Overview',
+            markdown: require('../../docs/declarative-ui/overview.md')
+          },
+          {
+            name: 'Layout Types',
+            markdown: require('../../docs/declarative-ui/layout-types.md')
+          },
+          {
+            name: 'Interactions',
+            markdown: require('../../docs/declarative-ui/interactions.md')
+          },
+          {
+            name: 'Layout Elements',
+            markdown: require('../../docs/declarative-ui/layout-elements.md')
+          },
+          {
+            name: 'Components',
+            markdown: require('../../docs/declarative-ui/components.md')
+          }
+        ]
+      },
+
       {
         name: 'Protocol Schema',
         children: [
           {
-            name: 'Core Protocol',
-            markdown: require('../../docs/protocol-schema/core-protocol.md')
+            name: 'Introduction',
+            markdown: require('../../docs/protocol-schema/introduction.md')
+          },
+          {
+            name: 'Core Types',
+            markdown: require('../../docs/protocol-schema/core-types.md')
           },
           {
             name: 'Session Protocol',
@@ -101,15 +133,12 @@ export default [
             markdown: require('../../docs/protocol-schema/style-specification.md')
           },
           {
-            name: 'Declarative UI',
-            markdown: require('../../docs/protocol-schema/declarative-ui.md')
-          },
-          {
             name: 'UI Primitives',
             markdown: require('../../docs/protocol-schema/ui-primitives.md')
           }
         ]
       },
+
       {
         name: 'Protocol Implementations',
         children: [
@@ -123,6 +152,7 @@ export default [
           }
         ]
       },
+
       {
         name: 'API Reference',
         children: [


### PR DESCRIPTION
To make the declarative UI more accessible we:

 - Move declarative UI to it's own top level section
 - Broke it up into several pages

To help with the flow of the documentation we:

 - Separated `core-protocol.md` into `core-types.md` and
   `introduction.md`
 - Move style and geometry specific content to those pages