### PR TITLE
Schema bug fix: allow stream set to only have ui primitives

### DIFF
--- a/modules/schema/core/stream_set.schema.json
+++ b/modules/schema/core/stream_set.schema.json
@@ -64,16 +64,6 @@
   "anyOf": [
     {
       "required": [
-        "annotations"
-      ]
-    },
-    {
-      "required": [
-        "future_instances"
-      ]
-    },
-    {
-      "required": [
         "poses"
       ]
     },
@@ -84,12 +74,27 @@
     },
     {
       "required": [
+        "ui_primitives"
+      ]
+    },
+    {
+      "required": [
         "time_series"
       ]
     },
     {
       "required": [
+        "future_instances"
+      ]
+    },
+    {
+      "required": [
         "variables"
+      ]
+    },
+    {
+      "required": [
+        "annotations"
       ]
     }
   ],

--- a/modules/schema/examples/core/stream_set/ui_primitive_only.json
+++ b/modules/schema/examples/core/stream_set/ui_primitive_only.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": 1001.3,
+  "ui_primitives": {
+    "/ui/mytable": {
+      "treetable": {
+        "columns": [
+          {
+            "display_text": "Name",
+            "type": "string"
+          }
+        ],
+        "nodes": [
+          {
+            "id": 0,
+            "column_values": ["Jim"]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
You have to have something in a stream_set for it to be valid, but
when ui_primitives were added they were not brought into that set.