### PR TITLE
Address an XVIZ v1 code path for a 'no data' entry

### DIFF
--- a/modules/parser/src/parsers/xviz-v2-common.js
+++ b/modules/parser/src/parsers/xviz-v2-common.js
@@ -43,8 +43,15 @@ export function getPrimitiveData(primitiveObject) {
   const {currentMajorVersion} = getXVIZSettings();
 
   if (currentMajorVersion === 1) {
-    if (primitiveObject instanceof Array && primitiveObject.length > 0) {
-      return {type: primitiveObject[0].type, primitives: primitiveObject};
+    if (primitiveObject instanceof Array) {
+      if (primitiveObject.length === 0) {
+        // The empty array implies 'no data' for this object, which is distinct
+        // from 'absence of data' which would happen if there was not primitive entry at all
+        return {type: null, primitives: primitiveObject};
+      } else if (primitiveObject.length > 0) {
+        // This is populated primitive data
+        return {type: primitiveObject[0].type, primitives: primitiveObject};
+      }
     }
   }
 

--- a/test/modules/parser/synchronizers/log-synchronizer.spec.js
+++ b/test/modules/parser/synchronizers/log-synchronizer.spec.js
@@ -10,12 +10,14 @@ const LOG_START_TIME = 0;
 const LOGS = {
   log1: [
     {attributes: {transmission_time: 100}, value: 1},
+    {attributes: {transmission_time: 101}},
     {attributes: {transmission_time: 200}, value: 2},
     {attributes: {transmission_time: 300}, value: 3}
   ],
   log2: [
     {time: 50, value: 10},
     {time: 100, value: 20},
+    {time: 101},
     {time: 250, value: 30},
     {time: 300.1, value: 40}
   ]
@@ -25,6 +27,7 @@ const LOGS = {
 const TEST_CASES = [
   {time: 0}, // out of range too early
   {time: 100, log1: 1, log2: 20}, // both in range
+  {time: 102, log1: 'empty_entry', log2: 'empty_entry'}, // empty entry
   {time: 200, log1: 2}, // one in range
   {time: 3000}, // out of range too late
   {time: -1000}, // out of range way too early
@@ -47,7 +50,7 @@ tape('LogSynchronizer#setTime', t => {
 
 tape('LogSynchronizer#getData', t => {
   resetXVIZConfigAndSettings();
-  setXVIZSettings({TIME_WINDOW: 0.4});
+  setXVIZSettings({TIME_WINDOW: 3});
   const logSynchronizer = new LogSynchronizer(LOG_START_TIME, LOGS);
 
   for (const tc of TEST_CASES) {
@@ -56,13 +59,21 @@ tape('LogSynchronizer#getData', t => {
     const data = logSynchronizer.getLogSlice();
     t.comment(`Set time to ${time}`);
     if (log1) {
-      t.equals(data.streams.log1.value, log1, 'Got correct log1 value');
+      if (log1 === 'empty_entry') {
+        t.equals(data.streams.log1.value, undefined, 'Got correct empty entry for log1');
+      } else {
+        t.equals(data.streams.log1.value, log1, 'Got correct log1 value');
+      }
     } else {
       t.equals(data.streams.log1, undefined, 'Got undefined log1 value');
     }
 
     if (log2) {
-      t.equals(data.streams.log2.value, log2, 'Got correct log2 value');
+      if (log2 === 'empty_entry') {
+        t.equals(data.streams.log2.value, undefined, 'Got correct empty entry for log2');
+      } else {
+        t.equals(data.streams.log2.value, log2, 'Got correct log2 value');
+      }
     } else {
       t.equals(data.streams.log2, undefined, 'Got undefined log2 value');
     }

--- a/test/modules/parser/synchronizers/stream-synchronizer.spec.js
+++ b/test/modules/parser/synchronizers/stream-synchronizer.spec.js
@@ -24,6 +24,13 @@ TEST_BUFFER.timeslices = [
     }
   },
   {
+    timestamp: 101,
+    streams: {
+      log1: {},
+      log2: {}
+    }
+  },
+  {
     timestamp: 200,
     streams: {
       log1: {value: 2}
@@ -53,6 +60,7 @@ TEST_BUFFER.timeslices = [
 const TEST_CASES = [
   {time: 0}, // out of range too early
   {time: 100, log1: 1, log2: 20}, // both in range
+  {time: 102, log1: 'empty_entry', log2: 'empty_entry'}, // empty entry
   {time: 200, log1: 2}, // one in range
   {time: 3000}, // out of range too late
   {time: -1000}, // out of range way too early
@@ -75,7 +83,7 @@ tape('StreamSynchronizer#setTime', t => {
 
 tape('StreamSynchronizer#getData', t => {
   resetXVIZConfigAndSettings();
-  setXVIZSettings({TIME_WINDOW: 0.4});
+  setXVIZSettings({TIME_WINDOW: 3});
   const logSynchronizer = new StreamSynchronizer(LOG_START_TIME, TEST_BUFFER);
 
   for (const tc of TEST_CASES) {
@@ -84,13 +92,21 @@ tape('StreamSynchronizer#getData', t => {
     t.comment(`Set time to ${time}`);
     const data = logSynchronizer.getLogSlice();
     if (log1) {
-      t.equals(data.streams.log1.value, log1, 'Got correct log1 value');
+      if (log1 === 'empty_entry') {
+        t.equals(data.streams.log1.value, undefined, 'Got correct empty entry for log1');
+      } else {
+        t.equals(data.streams.log1.value, log1, 'Got correct log1 value');
+      }
     } else {
       t.equals(data.streams.log1, undefined, 'Got undefined log1 value');
     }
 
     if (log2) {
-      t.equals(data.streams.log2.value, log2, 'Got correct log2 value');
+      if (log2 === 'empty_entry') {
+        t.equals(data.streams.log2.value, undefined, 'Got correct empty entry for log2');
+      } else {
+        t.equals(data.streams.log2.value, log2, 'Got correct log2 value');
+      }
     } else {
       t.equals(data.streams.log2, undefined, 'Got undefined log2 value');
     }


### PR DESCRIPTION
The distinction between 'absense of data' vs 'no data' is not being
handled in the parsing of XVIZ v1. Specifically when we transform from
XVIZ to an internal structure we are not handling this case correctly
result in an assertion error downstream from parsing in the
LogSynchronizer.

The fix applied here is to ensure when parsing v1 we handle the empty
stream array case and mark the entry with the appropriate timestamp
rather than returning the empty object.  This allows the downstream
logic to properly abort search when an entry without data is encoutered.

XVIZ Details:
Since XVIZ does not model a time to live, we rely on the presence of
a stream entry.  In the case of 'no data', which means we have a source
datum but there is no entry so we should treat the data as such and not
continue to search for data within the TIME_WINDOW.

An issue has been open up to investigate the current state of this case
for XVIZ 2 https://github.com/uber/xviz/issues/235