### PR TITLE
Update example server, parser and writer to be XVIZ 2 standard

### DIFF
--- a/modules/builder/src/writers/xviz-writer/xviz-writer.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-writer.js
@@ -25,18 +25,23 @@ class FileSink {
 }
 
 export default class XVIZWriter {
-  constructor(dataSink) {
+  constructor(dataSink, options = {envelope: true}) {
     this.sink = dataSink || new FileSink();
     this.frameTimings = {
       frames: new Map()
     };
     this.wroteFrameIndex = null;
+    this.options = options;
   }
 
   // xvizMetadata is the object returned
   // from a Builder.
   writeMetadata(xvizDirectory, xvizMetadata, options = {writeBinary: true, writeJson: false}) {
     this._saveTimestamp(xvizMetadata);
+
+    if (this.options.envelope) {
+      xvizMetadata = {type: 'xviz/metadata', data: xvizMetadata};
+    }
 
     if (options.writeBinary) {
       writeBinaryXVIZtoFile(this.sink, xvizDirectory, '1-frame', xvizMetadata, {
@@ -64,6 +69,10 @@ export default class XVIZWriter {
     }
 
     this._saveTimestamp(xvizFrame, frameNumber);
+
+    if (this.options.envelope) {
+      xvizFrame = {type: 'xviz/state_update', data: xvizFrame};
+    }
 
     if (options.writeBinary) {
       writeBinaryXVIZtoFile(this.sink, xvizDirectory, frameName(frameNumber), xvizFrame, {

--- a/modules/parser/src/parsers/parse-log-metadata.js
+++ b/modules/parser/src/parsers/parse-log-metadata.js
@@ -70,11 +70,13 @@ export function parseLogMetadataV2(data) {
   // Use XVIZ configuration to filter out unwanted / blacklisted streams
   const {STREAM_BLACKLIST} = getXVIZConfig();
   const streams = {};
-  Object.keys(originalStreams).forEach(streamName => {
-    if (!STREAM_BLACKLIST.has(streamName)) {
-      streams[streamName] = originalStreams[streamName];
-    }
-  });
+  if (originalStreams) {
+    Object.keys(originalStreams).forEach(streamName => {
+      if (!STREAM_BLACKLIST.has(streamName)) {
+        streams[streamName] = originalStreams[streamName];
+      }
+    });
+  }
 
   const logInfo = data.log_info || {};
   const logStartTime = logInfo.log_start_time;

--- a/modules/parser/src/parsers/parse-stream-data-message.js
+++ b/modules/parser/src/parsers/parse-stream-data-message.js
@@ -72,10 +72,12 @@ export function parseStreamDataMessage(message, onResult, onError, opts) {
       data = decode(message, true);
     }
 
+    let v2Type;
     let parseData = true;
     if (isEnvelope(data)) {
       const unpacked = unpackEnvelope(data);
       if (unpacked.namespace === 'xviz') {
+        v2Type = unpacked.type;
         data = unpacked.data;
       } else {
         parseData = false;
@@ -83,7 +85,7 @@ export function parseStreamDataMessage(message, onResult, onError, opts) {
     }
 
     if (parseData) {
-      const result = parseStreamLogData(data, opts);
+      const result = parseStreamLogData(data, {...opts, v2Type});
       onResult(result);
     }
   } catch (error) {
@@ -91,37 +93,28 @@ export function parseStreamDataMessage(message, onResult, onError, opts) {
   }
 }
 
-function checkV2MetadataFields(data) {
-  // Check for version 2.0.0
-  // TODO(twojtasz): proper semver parsing
-  if (data.streams && data.version && data.version === '2.0.0') {
-    data.type = 'metadata';
-  }
-}
-
 export function parseStreamLogData(data, opts = {}) {
-  // Handle v2 metadata that lacks a 'type'
-  // Plan is an envelope will wrap and replace this field check
-  checkV2MetadataFields(data);
-
   // TODO(twojtasz): this data.message is due an
   // uncoordinated change on the XVIZ server, temporary.
-  switch (data.type || data.message || data.update_type) {
+  const typeKey = opts.v2Type || data.type || data.message || data.update_type;
+
+  switch (typeKey) {
+    case 'state_update':
+      return parseTimesliceData(data, opts.convertPrimitive);
     case 'metadata':
       return {
         ...parseLogMetadata(data),
         // ensure application sees the metadata type set to the uppercase version
         type: LOG_STREAM_MESSAGE.METADATA
       };
+    case 'transform_log_done':
+      return {...data, type: LOG_STREAM_MESSAGE.DONE};
     case 'error':
       return {...data, message: 'Stream server error', type: LOG_STREAM_MESSAGE.ERROR};
+
+    // v1 types
     case 'done':
       return {...data, type: LOG_STREAM_MESSAGE.DONE};
-    case 'ack':
-      return null;
-    // v2 update types
-    case 'snapshot':
-    case 'incremental':
     default:
       //  TODO(twojtasz): XVIZ should be tagging this with a type
       return parseTimesliceData(data, opts.convertPrimitive);

--- a/test/modules/builder/writers/xviz-writer.spec.js
+++ b/test/modules/builder/writers/xviz-writer.spec.js
@@ -2,6 +2,21 @@
 import test from 'tape-catch';
 import {XVIZWriter} from '@xviz/builder';
 
+const SAMPLE_METADATA = {
+  log_info: {
+    start_time: 1,
+    end_time: 2
+  }
+};
+
+const SAMPLE_STATE_UPDATE = {
+  updates: [
+    {
+      timestamp: 100
+    }
+  ]
+};
+
 class MemorySink {
   constructor() {
     this.data = new Map();
@@ -42,7 +57,7 @@ test('XVIZWriter#default-ctor sink', t => {
 
 test('XVIZWriter#writeMetadata empty', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
   const data = {};
   builder.writeMetadata('test', data, {writeBinary: true, writeJson: true});
@@ -55,7 +70,7 @@ test('XVIZWriter#writeMetadata empty', t => {
 
 test('XVIZWriter#writeMetadata empty, write options off', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
   const data = {};
   builder.writeMetadata('test', data, {writeBinary: false, writeJson: false});
@@ -67,14 +82,9 @@ test('XVIZWriter#writeMetadata empty, write options off', t => {
 
 test('XVIZWriter#writeMetadata', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
-  const data = {
-    log_info: {
-      start_time: 1,
-      end_time: 2
-    }
-  };
+  const data = SAMPLE_METADATA;
 
   builder.writeMetadata('test', data, {writeBinary: true, writeJson: true});
 
@@ -84,9 +94,31 @@ test('XVIZWriter#writeMetadata', t => {
   t.end();
 });
 
+test('XVIZWriter#writeMetadataEnvelope', t => {
+  const sink = new MemorySink();
+  const builder = new XVIZWriter(sink, {envelope: true});
+
+  const data = SAMPLE_METADATA;
+
+  const expected = {
+    type: 'xviz/metadata',
+    data
+  };
+
+  builder.writeMetadata('test', data, {writeJson: true});
+
+  t.ok(sink.has('test', '1-frame.json'), 'wrote json metadata frame');
+  t.deepEquals(
+    JSON.parse(sink.get('test', '1-frame.json')),
+    expected,
+    'json metadata fetched matches'
+  );
+  t.end();
+});
+
 test('XVIZWriter#writeFrame missing updates', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
   const data = {};
 
@@ -100,7 +132,7 @@ test('XVIZWriter#writeFrame missing updates', t => {
 
 test('XVIZWriter#writeFrame updates missing timestamp', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
   const data = {
     updates: []
@@ -116,15 +148,9 @@ test('XVIZWriter#writeFrame updates missing timestamp', t => {
 
 test('XVIZWriter#writeFrame', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
-  const data = {
-    updates: [
-      {
-        timestamp: 100
-      }
-    ]
-  };
+  const data = SAMPLE_STATE_UPDATE;
 
   builder.writeFrame('test', 0, data, {writeJson: true});
 
@@ -133,17 +159,32 @@ test('XVIZWriter#writeFrame', t => {
   t.end();
 });
 
+test('XVIZWriter#writeFrameEnveloped', t => {
+  const sink = new MemorySink();
+  const builder = new XVIZWriter(sink, {envelope: true});
+
+  const data = SAMPLE_STATE_UPDATE;
+  const expected = {
+    type: 'xviz/state_update',
+    data
+  };
+
+  builder.writeFrame('test', 0, data, {writeJson: true});
+
+  t.ok(sink.has('test', '2-frame.json'), 'wrote json frame');
+  t.deepEquals(
+    JSON.parse(sink.get('test', '2-frame.json')),
+    expected,
+    'json frame fetched matches'
+  );
+  t.end();
+});
+
 test('XVIZWriter#default-ctor frames writeFrameIndex', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
-  const data = {
-    updates: [
-      {
-        timestamp: 100
-      }
-    ]
-  };
+  const data = SAMPLE_STATE_UPDATE;
 
   builder.writeFrame('test', 0, data);
   builder.writeFrameIndex('test');
@@ -164,15 +205,9 @@ test('XVIZWriter#default-ctor frames writeFrameIndex', t => {
 
 test('XVIZWriter#default-ctor frames writeFrame after writeFrameIndex', t => {
   const sink = new MemorySink();
-  const builder = new XVIZWriter(sink);
+  const builder = new XVIZWriter(sink, {envelope: false});
 
-  const data = {
-    updates: [
-      {
-        timestamp: 100
-      }
-    ]
-  };
+  const data = SAMPLE_STATE_UPDATE;
 
   builder.writeFrame('test', 0, data);
   builder.writeFrameIndex('test');

--- a/test/modules/parser/parsers/parse-stream-data-message.spec.js
+++ b/test/modules/parser/parsers/parse-stream-data-message.spec.js
@@ -11,7 +11,7 @@ import {
 import {XVIZValidator} from '@xviz/schema';
 
 import tape from 'tape-catch';
-import TestMetadataMessage from 'test-data/sample-metadata-message';
+import TestMetadataMessageV2 from 'test-data/sample-metadata-message';
 import TestMetadataMessageV1 from 'test-data/sample-metadata-message-v1';
 import TestFuturesMessageV1 from 'test-data/sample-frame-futures-v1';
 
@@ -142,7 +142,7 @@ tape('unpackEnvelope xviz', t => {
 tape('parseStreamLogData metadata', t => {
   resetXVIZConfigAndSettings();
 
-  const metaMessage = parseStreamLogData(TestMetadataMessage);
+  const metaMessage = parseStreamLogData(TestMetadataMessageV2, {v2Type: 'metadata'});
 
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.METADATA, 'Metadata type set');
   t.equals(
@@ -153,12 +153,12 @@ tape('parseStreamLogData metadata', t => {
 
   t.equals(
     metaMessage.eventStartTime,
-    TestMetadataMessage.log_info.start_time,
+    TestMetadataMessageV2.log_info.start_time,
     'Metadata eventStartTime set'
   );
   t.equals(
     metaMessage.eventEndTime,
-    TestMetadataMessage.log_info.end_time,
+    TestMetadataMessageV2.log_info.end_time,
     'Metadata eventEndTime set'
   );
 
@@ -180,12 +180,12 @@ tape('parseStreamLogData metadata v1', t => {
 
   t.equals(
     metaMessage.eventStartTime,
-    TestMetadataMessage.log_info.start_time,
+    TestMetadataMessageV2.log_info.start_time,
     'Metadata eventStartTime set'
   );
   t.equals(
     metaMessage.eventEndTime,
-    TestMetadataMessage.log_info.end_time,
+    TestMetadataMessageV2.log_info.end_time,
     'Metadata eventEndTime set'
   );
 
@@ -209,7 +209,7 @@ tape('parseStreamLogData unsupported version v2', t => {
   setXVIZConfig({supportedVersions: [1]});
 
   t.throws(
-    () => parseStreamLogData(TestMetadataMessage),
+    () => parseStreamLogData(TestMetadataMessageV2, {v2Type: 'metadata'}),
     /XVIZ version 2 is not supported/,
     'Throws if supportedVersions does not match currentMajorVersion'
   );
@@ -221,7 +221,7 @@ tape('parseStreamLogData undetectable version', t => {
   setXVIZConfig({supportedVersions: [2]});
 
   t.throws(
-    () => parseStreamLogData({...TestMetadataMessage, version: 'abc'}),
+    () => parseStreamLogData({...TestMetadataMessageV2, version: 'abc'}, {v2Type: 'metadata'}),
     /Unable to detect the XVIZ version/,
     'Throws if version exists but cannot parse major version'
   );
@@ -231,7 +231,7 @@ tape('parseStreamLogData undetectable version', t => {
 tape('parseStreamLogData metadata with full log time only', t => {
   resetXVIZConfigAndSettings();
 
-  const metaMessage = parseStreamLogData(metadataWithLogStartEnd);
+  const metaMessage = parseStreamLogData(metadataWithLogStartEnd, {v2Type: 'metadata'});
 
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.METADATA, 'Metadata type set');
   t.equals(
@@ -263,9 +263,12 @@ tape('parseStreamLogData validate result when missing updates', t => {
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
 
-  const metaMessage = parseStreamLogData({
-    update_type: 'snapshot'
-  });
+  const metaMessage = parseStreamLogData(
+    {
+      update_type: 'snapshot'
+    },
+    {v2Type: 'state_update'}
+  );
 
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Type after parse set to error');
   t.ok(/Missing required/.test(metaMessage.message), 'Message details on what is missing');
@@ -277,10 +280,13 @@ tape('parseStreamLogData validate result when updates is empty', t => {
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
 
-  const metaMessage = parseStreamLogData({
-    update_type: 'snapshot',
-    updates: []
-  });
+  const metaMessage = parseStreamLogData(
+    {
+      update_type: 'snapshot',
+      updates: []
+    },
+    {v2Type: 'state_update'}
+  );
 
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Type after parse set to error');
   t.ok(/"updates" has length of 0/.test(metaMessage.message), 'Message details length is 0');
@@ -292,10 +298,13 @@ tape('parseStreamLogData validate result when missing timestamp in updates', t =
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
 
-  const metaMessage = parseStreamLogData({
-    update_type: 'snapshot',
-    updates: [{}]
-  });
+  const metaMessage = parseStreamLogData(
+    {
+      update_type: 'snapshot',
+      updates: [{}]
+    },
+    {v2Type: 'state_update'}
+  );
 
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Type after parse set to error');
   t.ok(
@@ -310,10 +319,7 @@ tape('parseStreamLogData error', t => {
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
 
-  const metaMessage = parseStreamLogData({
-    ...TestTimesliceMessageV2,
-    type: 'error'
-  });
+  const metaMessage = parseStreamLogData({message: 'my message'}, {v2Type: 'error'});
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.ERROR, 'Metadata type set to error');
 
   t.end();
@@ -324,40 +330,52 @@ tape('parseStreamLogData timeslice INCOMPLETE', t => {
   setXVIZSettings({currentMajorVersion: 2});
 
   // NOTE: no explicit type for this message yet.
-  let metaMessage = parseStreamLogData({
-    ...TestTimesliceMessageV2,
-    timestamp: null
-  });
+  let metaMessage = parseStreamLogData(
+    {
+      ...TestTimesliceMessageV2,
+      timestamp: null
+    },
+    {v2Type: 'state_update'}
+  );
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Missing timestamp is ok');
 
-  metaMessage = parseStreamLogData({
-    ...TestTimesliceMessageV2,
-    updates: [{updates: null}]
-  });
+  metaMessage = parseStreamLogData(
+    {
+      ...TestTimesliceMessageV2,
+      updates: [{updates: null}]
+    },
+    {v2Type: 'state_update'}
+  );
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Missing updates incomplete');
 
-  metaMessage = parseStreamLogData({
-    ...TestTimesliceMessageV2,
-    updates: [
-      {
-        poses: {
-          '/vehicle_pose': {
-            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6}
+  metaMessage = parseStreamLogData(
+    {
+      ...TestTimesliceMessageV2,
+      updates: [
+        {
+          poses: {
+            '/vehicle_pose': {
+              mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6}
+            }
           }
         }
-      }
-    ]
-  });
+      ]
+    },
+    {v2Type: 'state_update'}
+  );
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Missing updates is incomplete');
 
-  metaMessage = parseStreamLogData({
-    ...TestTimesliceMessageV2,
-    updates: [
-      {
-        timestamp: null
-      }
-    ]
-  });
+  metaMessage = parseStreamLogData(
+    {
+      ...TestTimesliceMessageV2,
+      updates: [
+        {
+          timestamp: null
+        }
+      ]
+    },
+    {v2Type: 'state_update'}
+  );
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.INCOMPLETE, 'Missing timestamp is incomplete');
 
   t.end();
@@ -368,7 +386,7 @@ tape('parseStreamLogData timeslice', t => {
   setXVIZSettings({currentMajorVersion: 2});
 
   // NOTE: no explicit type for this message yet.
-  const metaMessage = parseStreamLogData({...TestTimesliceMessageV2});
+  const metaMessage = parseStreamLogData({...TestTimesliceMessageV2}, {v2Type: 'state_update'});
   t.equals(metaMessage.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Message type set for timeslice');
   t.equals(
     metaMessage.timestamp,
@@ -703,6 +721,68 @@ tape('parseStreamDataMessage enveloped', t => {
     TestTimesliceMessageV2.updates[0].poses['/vehicle_pose'].timestamp,
     'Message timestamp set from vehicle_pose'
   );
+
+  t.end();
+});
+
+tape('parseStreamDataMessage#enveloped#metadata', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZSettings({currentMajorVersion: 2});
+
+  const enveloped = {
+    type: 'xviz/metadata',
+    data: {version: '2.0.0'}
+  };
+
+  let result;
+  let error;
+  const opts = {};
+  parseStreamDataMessage(
+    enveloped,
+    newResult => {
+      result = newResult;
+    },
+    newError => {
+      error = newError;
+    },
+    opts
+  );
+
+  t.equals(undefined, error, 'No errors received while parsing');
+  t.notEquals(undefined, result, 'Update units');
+  t.equals(result.type, LOG_STREAM_MESSAGE.METADATA, 'Message type set for metadata');
+  t.equals(result.version, enveloped.data.version);
+
+  t.end();
+});
+
+tape('parseStreamDataMessage#enveloped#transform_log_done', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZSettings({currentMajorVersion: 2});
+
+  const enveloped = {
+    type: 'xviz/transform_log_done',
+    data: {id: 'foo'}
+  };
+
+  let result;
+  let error;
+  const opts = {};
+  parseStreamDataMessage(
+    enveloped,
+    newResult => {
+      result = newResult;
+    },
+    newError => {
+      error = newError;
+    },
+    opts
+  );
+
+  t.equals(undefined, error, 'No errors received while parsing');
+  t.notEquals(undefined, result, 'Update units');
+  t.equals(result.type, LOG_STREAM_MESSAGE.DONE, 'Message type set to done');
+  t.equals(result.id, enveloped.data.id);
 
   t.end();
 });


### PR DESCRIPTION
The big changes were:

 - writer: output enveloped XVIZ data in both JSON & binary
 - server: use envelope, and handle only standard messages
 - parser: use envelope type to simplify parsing

This runs through the standard documented session protocol, except it
only supports supplying startup data through URL parameters and not a
separate start message.

The matching client support is in uber/streetscape.gl#182