### PR TITLE
Preserve additional properties defined in pose

### DIFF
--- a/modules/parser/src/parsers/parse-xviz-pose.js
+++ b/modules/parser/src/parsers/parse-xviz-pose.js
@@ -32,5 +32,5 @@ export function parseXVIZPose(pose) {
     });
   }
 
-  return result;
+  return {...pose, ...result};
 }

--- a/test/modules/parser/index.js
+++ b/test/modules/parser/index.js
@@ -9,6 +9,7 @@ import './parsers/filter-vertices.spec';
 import './parsers/parse-stream-data-message.spec';
 import './parsers/parse-stream-message.spec';
 import './parsers/parse-vehicle-pose.spec';
+import './parsers/parse-xviz-pose.spec';
 import './parsers/parse-xviz-stream.spec';
 import './parsers/serialize.spec';
 import './parsers/xviz-v2-common.spec';

--- a/test/modules/parser/parsers/parse-xviz-pose.spec.js
+++ b/test/modules/parser/parsers/parse-xviz-pose.spec.js
@@ -1,0 +1,46 @@
+import {parseXVIZPose} from '@xviz/parser/parsers/parse-xviz-pose';
+
+import tape from 'tape-catch';
+
+const testXVIZPose = {
+  mapOrigin: {
+    longitude: 8.422885,
+    latitude: 49.0112128,
+    altitude: 112.8349227
+  },
+  orientation: [0.0210803, -0.009091, -2.1248735],
+  position: [20.6404841, -3317.4369679, 518.4297592],
+  timestamp: 1172686281.40241
+};
+
+function parsedPoseCheck(t, parsedPose, xvizPose) {
+  t.equal(parsedPose.x, xvizPose.position[0]);
+  t.equal(parsedPose.y, xvizPose.position[1]);
+  t.equal(parsedPose.z, xvizPose.position[2]);
+
+  t.equal(parsedPose.roll, xvizPose.orientation[0]);
+  t.equal(parsedPose.pitch, xvizPose.orientation[1]);
+  t.equal(parsedPose.yaw, xvizPose.orientation[2]);
+
+  t.equal(parsedPose.latitude, xvizPose.mapOrigin.latitude);
+  t.equal(parsedPose.longitude, xvizPose.mapOrigin.longitude);
+  t.equal(parsedPose.altitude, xvizPose.mapOrigin.altitude);
+}
+
+tape('parseXVIZPose#simple', t => {
+  const result = parseXVIZPose(testXVIZPose);
+  parsedPoseCheck(t, result, testXVIZPose);
+  t.end();
+});
+
+tape.only('parseXVIZPose#additionalProperties preserved', t => {
+  const additionalPropPose = {
+    ...testXVIZPose,
+    extraProp: true
+  };
+
+  const result = parseXVIZPose(additionalPropPose);
+  parsedPoseCheck(t, result, additionalPropPose);
+  t.equal(result.extraProp, true);
+  t.end();
+});


### PR DESCRIPTION
- the spec allows for additional properties to be allowed
- this is needed for custom pose handling systems