### PR TITLE
Support flat JSON polygon, polyline and point input data

### DIFF
--- a/modules/parser/src/parsers/xviz-primitives-v2.js
+++ b/modules/parser/src/parsers/xviz-primitives-v2.js
@@ -1,4 +1,5 @@
 import {filterVertices} from './filter-vertices';
+import {ensureUnFlattenedVertices} from './xviz-v2-common';
 import {PRIMITIVE_CAT} from './parse-xviz-primitive';
 import base64js from 'base64-js';
 
@@ -28,6 +29,8 @@ export default {
     category: PRIMITIVE_CAT.FEATURE,
     validate: (primitive, streamName, time) => primitive.vertices && primitive.vertices.length >= 2,
     normalize: primitive => {
+      primitive.vertices = ensureUnFlattenedVertices(primitive.vertices);
+
       // z is required by filterVertices
       primitive.vertices.forEach(v => {
         v[2] = v[2] || 0;
@@ -43,6 +46,8 @@ export default {
     category: PRIMITIVE_CAT.FEATURE,
     validate: (primitive, streamName, time) => primitive.vertices && primitive.vertices.length >= 3,
     normalize: primitive => {
+      primitive.vertices = ensureUnFlattenedVertices(primitive.vertices);
+
       // This is a polygon primitive which per XVIZ protocol implicitly says
       // that the provided path is closed. Push a copy of first vert to end of array.
       // Array comparison turns out to be expensive. Looks like the polygon returned
@@ -56,6 +61,8 @@ export default {
     category: PRIMITIVE_CAT.POINTCLOUD,
     validate: (primitive, streamName, time) => primitive.points && primitive.points.length > 0,
     normalize: primitive => {
+      primitive.points = ensureUnFlattenedVertices(primitive.points);
+
       // Alias XVIZ 2.0 to normalized vertices field.
       primitive.vertices = primitive.points;
       aliasId(primitive);

--- a/modules/parser/src/parsers/xviz-v2-common.js
+++ b/modules/parser/src/parsers/xviz-v2-common.js
@@ -72,3 +72,28 @@ export function getPrimitiveData(primitiveObject) {
   // TODO(twojtasz): Cleanup data flow as downstream expects an object rather than an error.
   return {};
 }
+
+/**
+ *  Turns arrays from [1, 2, 3, 4, 5, 6] to [[1, 2, 3], [4, 5, 6]]. The array
+ *  must have a length a multiple of 3.
+ */
+export function unFlattenVertices(vertices) {
+  const result = [];
+  for (let i = 0; i < vertices.length; i = i + 3) {
+    result.push([vertices[i], vertices[i + 1], vertices[i + 2]]);
+  }
+
+  return result;
+}
+
+/**
+ *  Unflattens an array only if it's already flat. Only works on arrays with a
+ *  length that is a multiple of 3.
+ */
+export function ensureUnFlattenedVertices(vertices) {
+  if (vertices.length > 0 && !Array.isArray(vertices[0])) {
+    return unFlattenVertices(vertices);
+  }
+
+  return vertices;
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-inline-import": "^3.0.0",
     "babel-plugin-istanbul": "^5.0.0",
     "babel-plugin-version-inline": "^1.0.0",
+    "clone": "^2.1.2",
     "coveralls": "^2.13.0",
     "eslint": "^4.13.1",
     "eslint-config-prettier": "^2.9.0",

--- a/test/modules/parser/parsers/parse-stream-data-message.spec.js
+++ b/test/modules/parser/parsers/parse-stream-data-message.spec.js
@@ -11,6 +11,8 @@ import {
 import {XVIZValidator} from '@xviz/schema';
 
 import tape from 'tape-catch';
+import clone from 'clone';
+
 import TestMetadataMessageV2 from 'test-data/sample-metadata-message';
 import TestMetadataMessageV1 from 'test-data/sample-metadata-message-v1';
 import TestFuturesMessageV1 from 'test-data/sample-frame-futures-v1';
@@ -448,37 +450,7 @@ tape('parseStreamLogData preProcessPrimitive type change', t => {
 tape('parseStreamLogData pointCloud timeslice', t => {
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
-  const PointCloudTestTimesliceMessage = {
-    update_type: 'snapshot',
-    updates: [
-      {
-        timestamp: 1001.0,
-        poses: {
-          '/vehicle_pose': {
-            timestamp: 1001.0,
-            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
-            position: [1.1, 2.2, 3.3],
-            orientation: [0.1, 0.2, 0.3]
-          }
-        },
-        primitives: {
-          '/test/stream': {
-            points: [
-              {
-                base: {
-                  object_id: 1234,
-                  style: {
-                    fill_color: [255, 255, 255]
-                  }
-                },
-                points: [[1000, 1000, 200]]
-              }
-            ]
-          }
-        }
-      }
-    ]
-  };
+  const PointCloudTestTimesliceMessage = TestTimesliceMessageV2;
 
   // NOTE: no explicit type for this message yet.
   const slice = parseStreamLogData({...PointCloudTestTimesliceMessage});
@@ -493,41 +465,102 @@ tape('parseStreamLogData pointCloud timeslice', t => {
   t.end();
 });
 
+tape('parseStreamLogData polyline flat', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZSettings({currentMajorVersion: 2});
+  const TestTimeslice = clone(TestTimesliceMessageV2);
+  TestTimeslice.updates[0].primitives['/test/stream'] = {
+    polylines: [
+      {
+        base: {
+          object_id: '1234',
+          style: {
+            fill_color: [255, 255, 255]
+          }
+        },
+        vertices: [1000, 1000, 200, 1000, 1000, 250]
+      }
+    ]
+  };
+
+  // NOTE: no explicit type for this message yet.
+  const slice = parseStreamLogData({...TestTimeslice});
+  t.equals(slice.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Message type set for timeslice');
+
+  const features = slice.streams['/test/stream'].features;
+  t.equals(features.length, 1, 'has has object');
+  t.equals(features[0].type, 'polyline', 'type is polyline');
+  t.deepEquals(features[0].vertices, [[1000, 1000, 200], [1000, 1000, 250]], 'array is nested');
+
+  t.end();
+});
+
+tape('parseStreamLogData polygon flat', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZSettings({currentMajorVersion: 2});
+  const TestTimeslice = clone(TestTimesliceMessageV2);
+  TestTimeslice.updates[0].primitives['/test/stream'] = {
+    polygons: [
+      {
+        base: {
+          object_id: '1234',
+          style: {
+            fill_color: [255, 255, 255]
+          }
+        },
+        vertices: [1000, 1000, 200, 1000, 1000, 250, 1000, 1000, 300]
+      }
+    ]
+  };
+
+  // NOTE: no explicit type for this message yet.
+  const slice = parseStreamLogData({...TestTimeslice});
+  t.equals(slice.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Message type set for timeslice');
+
+  const features = slice.streams['/test/stream'].features;
+  t.equals(features.length, 1, 'has has object');
+  t.equals(features[0].type, 'polygon', 'type is polygon');
+  t.deepEquals(
+    features[0].vertices,
+    // We automatically close loops...
+    [[1000, 1000, 200], [1000, 1000, 250], [1000, 1000, 300], [1000, 1000, 200]],
+    'array is nested and looped back'
+  );
+
+  t.end();
+});
+
+tape('parseStreamLogData flat JSON pointCloud', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZSettings({currentMajorVersion: 2});
+  const PointCloudTestTimesliceMessage = clone(TestTimesliceMessageV2);
+  PointCloudTestTimesliceMessage.updates[0].primitives['/test/stream'].points.points = [
+    1000,
+    1000,
+    200
+  ];
+
+  // NOTE: no explicit type for this message yet.
+  const slice = parseStreamLogData({...PointCloudTestTimesliceMessage});
+  t.equals(slice.type, LOG_STREAM_MESSAGE.TIMESLICE, 'Message type set for timeslice');
+  t.ok(slice.streams['/test/stream'].pointCloud, 'has a point cloud');
+
+  const pointCloud = slice.streams['/test/stream'].pointCloud;
+  t.equals(pointCloud.numInstances, 1, 'Has 1 instance');
+  t.deepEquals(pointCloud.positions, [1000, 1000, 200], 'Has 3 values in positions');
+  t.equals(pointCloud.colors.length, 4, 'Has 4 values in colors');
+
+  t.end();
+});
+
 tape('parseStreamLogData pointCloud timeslice TypedArray', t => {
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
 
-  const PointCloudTestTimesliceMessage = {
-    update_type: 'snapshot',
-    updates: [
-      {
-        timestamp: 1001.0,
-        poses: {
-          '/vehicle_pose': {
-            timestamp: 1001.0,
-            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
-            position: [1.1, 2.2, 3.3],
-            orientation: [0.1, 0.2, 0.3]
-          }
-        },
-        primitives: {
-          '/test/stream': {
-            points: [
-              {
-                base: {
-                  object_id: '1234',
-                  style: {
-                    fill_color: [255, 255, 255]
-                  }
-                },
-                points: new Float32Array([1000, 1000, 200])
-              }
-            ]
-          }
-        }
-      }
-    ]
-  };
+  const PointCloudTestTimesliceMessage = clone(TestTimesliceMessageV2);
+  PointCloudTestTimesliceMessage.updates[0].primitives[
+    '/test/stream'
+  ].points.points = new Float32Array([1000, 1000, 200]);
 
   // NOTE: no explicit type for this message yet.
   const slice = parseStreamLogData({...PointCloudTestTimesliceMessage});
@@ -546,46 +579,16 @@ tape('parseStreamLogData pointCloud timeslice', t => {
   resetXVIZConfigAndSettings();
   setXVIZSettings({currentMajorVersion: 2});
 
-  const PointCloudTestTimesliceMessage = {
-    update_type: 'snapshot',
-    updates: [
-      {
-        timestamp: 1001.0,
-        poses: {
-          '/vehicle_pose': {
-            timestamp: 1001.0,
-            mapOrigin: {longitude: 11.2, latitude: 33.4, altitude: 55.6},
-            position: [1.1, 2.2, 3.3],
-            orientation: [0.1, 0.2, 0.3]
-          }
-        },
-        primitives: {
-          '/test/stream': {
-            points: [
-              {
-                object_id: '1234',
-                base: {
-                  style: {
-                    fill_color: [255, 255, 255]
-                  }
-                },
-                points: [[1000, 1000, 200]]
-              },
-              {
-                object_id: '1235',
-                base: {
-                  style: {
-                    fill_color: [255, 255, 255]
-                  }
-                },
-                points: new Float32Array([1000, 1000, 200])
-              }
-            ]
-          }
-        }
+  const PointCloudTestTimesliceMessage = clone(TestTimesliceMessageV2);
+  PointCloudTestTimesliceMessage.updates[0].primitives['/test/stream'].points.push({
+    object_id: '1235',
+    base: {
+      style: {
+        fill_color: [255, 255, 255]
       }
-    ]
-  };
+    },
+    points: new Float32Array([1000, 1000, 200])
+  });
 
   // NOTE: no explicit type for this message yet.
   const slice = parseStreamLogData({...PointCloudTestTimesliceMessage});

--- a/test/modules/parser/parsers/xviz-v2-common.spec.js
+++ b/test/modules/parser/parsers/xviz-v2-common.spec.js
@@ -1,4 +1,8 @@
-import {parseVersionString} from '@xviz/parser/parsers/xviz-v2-common';
+import {
+  parseVersionString,
+  unFlattenVertices,
+  ensureUnFlattenedVertices
+} from '@xviz/parser/parsers/xviz-v2-common';
 
 import tape from 'tape-catch';
 
@@ -56,5 +60,22 @@ tape('XVIZ V2 Common#parseVersionString invalid strings', t => {
   result = parseVersionString('1-2-3');
   validateVersion(t, result, 1, null, null);
 
+  t.end();
+});
+
+tape('XVIZ V2 Common#unFlattenVertices', t => {
+  const input = [1, 2, 3, 4, 5, 6];
+  const expected = [[1, 2, 3], [4, 5, 6]];
+
+  t.deepEqual(unFlattenVertices(input), expected, 'vertices inflated');
+  t.end();
+});
+
+tape('XVIZ V2 Common#ensureUnFlattenedVertices', t => {
+  const input = [1, 2, 3, 4, 5, 6];
+  const expected = [[1, 2, 3], [4, 5, 6]];
+
+  t.deepEqual(ensureUnFlattenedVertices(input), expected, 'vertices inflated');
+  t.deepEqual(ensureUnFlattenedVertices(expected), expected, 'vertices unchanged');
   t.end();
 });


### PR DESCRIPTION
The spec was updated to allow for these type to take data in the
"flat" form of `[1, 2, 3, 4, 5, 6]` instead of `[[1, 2, 3], [4, 5,
6]]`.  This updates the XVIZ parser to support this by "re-nesting"
any input data that comes in this form.