### PR TITLE
Fix example server to handle lack of indices

### DIFF
--- a/examples/server/xviz-serve-data.js
+++ b/examples/server/xviz-serve-data.js
@@ -66,7 +66,7 @@ function loadTimingIndex(data_directory) {
     console.log('Timing index file is missing the "timing" entry');
   }
 
-  return null;
+  return [];
 }
 
 // Check for data files or tar.gz and extract as necessary


### PR DESCRIPTION
The code existed to generate these on demand but we needed to return
no indices instead of null to trigger it.