### PR TITLE
Fix typo in components documentation

### DIFF
--- a/docs/declarative-ui/components.md
+++ b/docs/declarative-ui/components.md
@@ -144,9 +144,9 @@ style these regions apply style information to the `x` stream.
 
 | **Name** | **Type**    | **Description**                                                                                                                 |
 | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `x`      | `stream_id` | The X axis values of the regions, , expected a floating point variable stream. Style's on this stream apply to the full region. |
-| `yMin`   | `stream_id` | The visible lower bound of the region on the Y axis, expected a floating point variable stream.                                 |
-| `yMax`   | `stream_id` | The visible upper bound of the region on the Y axis, , expected a floating point variable stream.                               |
+| `x`      | `stream_id` | The X axis values of the regions, expects a floating point variable stream. Style's on this stream apply to the full region. |
+| `yMin`   | `stream_id` | The visible lower bound of the region on the Y axis, expects a floating point variable stream.                                 |
+| `yMax`   | `stream_id` | The visible upper bound of the region on the Y axis, expects a floating point variable stream.                               |
 
 ### Supported Interactions
 


### PR DESCRIPTION
Double commas snuck in and the wording is a little awkward.