### PR TITLE
Add server options for live XVIZ sessions and dynamic XVIZ test scenarios

### DIFF
--- a/examples/server/args.js
+++ b/examples/server/args.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const {ArgumentParser} = require('argparse');
 const path = require('path');
 
@@ -7,7 +8,6 @@ const parser = new ArgumentParser({
 });
 
 parser.addArgument(['-d', '--data_directory'], {
-  required: true,
   help: 'Directory to serve data from. Relative path will be resolved relative to /data/generated/'
 });
 
@@ -24,13 +24,25 @@ parser.addArgument(['--frame_limit'], {
 parser.addArgument(['--delay'], {
   defaultValue: 50,
   type: Number,
-  help: 'Message send interval, 50ms as default'
+  help: 'Message send interval in milliseconds. 50ms as default'
 });
 
 parser.addArgument(['--duration'], {
-  defaultValue: 30000,
+  defaultValue: 30,
   type: Number,
-  help: 'Set duration of log data if not specified, 30 seconds default'
+  help: 'Set duration in seconds of log data. 30s as default'
+});
+
+parser.addArgument(['--scenario'], {
+  defaultValue: '',
+  type: String,
+  help: 'Select from available scenarios: "circle", "straight"'
+});
+
+parser.addArgument(['--live'], {
+  defaultValue: false,
+  action: 'storeTrue',
+  help: 'Behave like a live system and send XVIZ data immediately after metadata.'
 });
 
 parser.addArgument(['--skip_images'], {
@@ -40,7 +52,9 @@ parser.addArgument(['--skip_images'], {
 
 module.exports = function getArgs() {
   const args = parser.parseArgs();
-  // eslint-disable-next-line camelcase
-  args.data_directory = path.resolve(__dirname, '../../data/generated/', args.data_directory);
+  if (args.data_directory) {
+    args.data_directory = path.resolve(__dirname, '../../data/generated/', args.data_directory);
+  }
+
   return args;
 };

--- a/examples/server/scenario-circle.js
+++ b/examples/server/scenario-circle.js
@@ -1,0 +1,135 @@
+/* Generated XVIZ for a scenario that is a
+ * circular path on a grid
+ * - no start end time in metadata
+ * - stream metadata for coordinate & styling
+ */
+
+const DEG_1_AS_RAD = Math.PI / 180;
+const DEG_6_AS_RAD = 6 * DEG_1_AS_RAD;
+const DEG_90_AS_RAD = 90 * DEG_1_AS_RAD;
+
+const circle_metadata = {
+  type: 'xviz/metadata',
+  data: {
+    version: '2.0.0',
+    streams: {
+      ['/vehicle_pose']: {},
+      ['/circle']: {
+        coordinate: 'IDENTITY',
+        stream_style: {
+          fill_color: [200, 0, 70, 128]
+        }
+      },
+      ['/ground_grid_h']: {
+        coordinate: 'IDENTITY',
+        stream_style: {
+          stroked: true,
+          stroke_width: 0.2,
+          stroke_color: [0, 255, 0, 128]
+        }
+      },
+      ['/ground_grid_v']: {
+        coordinate: 'IDENTITY',
+        stream_style: {
+          stroked: true,
+          stroke_width: 0.2,
+          stroke_color: [0, 255, 0, 128]
+        }
+      }
+    }
+  }
+};
+
+// Special metadata for the non-live test case
+const circle_log_metadata = JSON.parse(JSON.stringify(circle_metadata));
+circle_log_metadata.data.log_info = {
+  log_start_time: 1000,
+  log_end_time: 1030
+};
+
+class CircleScenario {
+  constructor(ts) {
+    // Get starting timestamp
+    this.timestamp = ts || Date.now() * 1000;
+  }
+
+  getFrame(frameNumber) {
+    return this._getFrame(frameNumber);
+  }
+
+  _getFrame(frameNumber) {
+    const timestamp = this.timestamp + 0.1 * frameNumber;
+
+    return {
+      type: 'xviz/state_update',
+      data: {
+        update_type: 'snapshot',
+        updates: [
+          {
+            timestamp,
+            poses: this._drawPose(frameNumber, timestamp),
+            primitives: this._drawGrid()
+          }
+        ]
+      }
+    };
+  }
+
+  _drawPose(frameNumber, timestamp) {
+    // 6 degrees per frame
+
+    const angle = frameNumber * 6 * DEG_1_AS_RAD;
+    return {
+      '/vehicle_pose': {
+        timestamp,
+        // Make the car orient the the proper direction on the circle
+        orientation: [0, 0, DEG_90_AS_RAD + frameNumber * DEG_6_AS_RAD],
+        position: [30 * Math.cos(angle), 30 * Math.sin(angle), 0]
+      }
+    };
+  }
+
+  _drawGrid() {
+    const grid = [-40, -30, -20, -10, 0, 10, 20, 30, 40];
+
+    const gridXVIZ_h = grid.map(x => {
+      return {
+        vertices: [x, -40, 0, x, 40, 0]
+      };
+    });
+
+    const gridXVIZ_v = grid.map(y => {
+      return {
+        vertices: [-40, y, 0, 40, y, 0]
+      };
+    });
+
+    return {
+      ['/ground_grid_h']: {
+        polylines: gridXVIZ_h
+      },
+      ['/ground_grid_v']: {
+        polylines: gridXVIZ_v
+      },
+      ['/circle']: {
+        circles: [
+          {
+            center: [0.0, 0.0, 0.0],
+            radius: 30.0
+          }
+        ]
+      }
+    };
+  }
+}
+
+module.exports = {
+  circle: {
+    metadata: circle_metadata,
+    generator: new CircleScenario()
+  },
+  circle_log: {
+    metadata: circle_log_metadata,
+    generator: new CircleScenario(circle_log_metadata.data.log_info.log_start_time)
+  }
+};

--- a/examples/server/scenario-straight.js
+++ b/examples/server/scenario-straight.js
@@ -1,0 +1,102 @@
+/* Generated XVIZ for a scenario that is a
+ * straight path with relative horizontal lines
+ * for movement indication
+ * - no start end time in metadata
+ * - no streams in metadata
+ *   - this forces everything to be vehicle_relative
+ */
+
+const DEG_1_AS_RAD = Math.PI / 180;
+
+const straight_metadata = {
+  type: 'xviz/metadata',
+  data: {
+    version: '2.0.0'
+  }
+};
+
+// Special metadata for the non-live test case
+const straight_log_metadata = JSON.parse(JSON.stringify(straight_metadata));
+straight_log_metadata.data.log_info = {
+  log_start_time: 1000,
+  log_end_time: 1030
+};
+
+class StraightScenario {
+  constructor(ts) {
+    // Get starting timestamp
+    this.timestamp = ts || Date.now() * 1000;
+  }
+
+  getFrame(frameNumber) {
+    return this._getFrame(frameNumber);
+  }
+
+  _getFrame(frameNumber) {
+    const timestamp = this.timestamp + 0.1 * frameNumber;
+
+    return {
+      type: 'xviz/state_update',
+      data: {
+        update_type: 'snapshot',
+        updates: [
+          {
+            timestamp,
+            poses: this._drawPose(frameNumber, timestamp),
+            primitives: this._drawLines(frameNumber)
+          }
+        ]
+      }
+    };
+  }
+
+  _drawPose(frameNumber, timestamp) {
+    return {
+      '/vehicle_pose': {
+        timestamp,
+        orientation: [0, 0, 0],
+        position: [0, frameNumber, 0]
+      }
+    };
+  }
+
+  _drawLines(frameNumber) {
+    const lineSpacing = [-15, -10, -5, 0, 5, 10, 15, 20];
+
+    const offset = frameNumber % 5;
+    const colorCycle = Math.cos(frameNumber * 2 * DEG_1_AS_RAD);
+    const lineSpacingXVIZ = lineSpacing.map((x, index) => {
+      return {
+        base: {
+          style: {
+            stroke_width: 0.2,
+            stroke_color: [
+              // Generate cyclical colors
+              120 + Math.cos(frameNumber * 2 * DEG_1_AS_RAD) * 90,
+              60 + Math.cos(frameNumber * DEG_1_AS_RAD) * 30,
+              90 + Math.sin(frameNumber * 3 * DEG_1_AS_RAD) * 60
+            ]
+          }
+        },
+        vertices: [x - offset, -40, 0, x - offset, 40, 0]
+      };
+    });
+
+    return {
+      ['/ground_lines']: {
+        polylines: lineSpacingXVIZ
+      }
+    };
+  }
+}
+
+module.exports = {
+  straight: {
+    metadata: straight_metadata,
+    generator: new StraightScenario()
+  },
+  straight_log: {
+    metadata: straight_log_metadata,
+    generator: new StraightScenario(straight_log_metadata.data.log_info.log_start_time)
+  }
+};

--- a/examples/server/scenarios.js
+++ b/examples/server/scenarios.js
@@ -1,0 +1,38 @@
+const ScenarioCircle = require('./scenario-circle');
+const ScenarioStraight = require('./scenario-straight');
+
+const Scenario = {
+  ...ScenarioCircle,
+  ...ScenarioStraight
+};
+
+function loadScenario(name, isLive, duration) {
+  // Construct proper scenario for live vs log
+  const scenarioName = isLive ? name : name + '_log';
+
+  const scenario = Scenario[scenarioName];
+  if (!scenario) {
+    throw new Error('No scenario named ' + scenario + 'found.');
+  }
+
+  const data = {
+    metadata: JSON.stringify(scenario.metadata),
+    frames: [],
+    timing: []
+  };
+
+  const hz = 10;
+  const frameLimit = duration * hz;
+
+  for (let i = 0; i < frameLimit; i++) {
+    const frame = scenario.generator.getFrame(i);
+    data.timing.push(frame.data.updates[0].timestamp);
+    data.frames.push(JSON.stringify(frame));
+  }
+
+  return data;
+}
+
+module.exports = {
+  loadScenario
+};

--- a/examples/server/xviz-serve-data.js
+++ b/examples/server/xviz-serve-data.js
@@ -8,6 +8,8 @@ const process = require('process');
 const {deltaTimeMs, extractZipFromFile} = require('./serve');
 const {parseBinaryXVIZ} = require('@xviz/parser');
 
+const {loadScenario} = require('./scenarios');
+
 // TODO: auxillary timestamp tracking & images are not handled
 
 const FRAME_DATA_SUFFIX = '-frame.glb';
@@ -262,8 +264,10 @@ function connectionId() {
 
 // Connection State
 class ConnectionContext {
-  constructor(settings, metadata, frames, frameTiming) {
+  constructor(settings, metadata, frames, frameTiming, loadFrameData) {
     this.metadata = metadata;
+
+    this._loadFrameData = loadFrameData;
 
     this.connectionId = connectionId();
 
@@ -298,6 +302,12 @@ class ConnectionContext {
 
     // On connection send metadata
     this.sendMetadataResp();
+
+    // 'live' mode will not get the 'xviz/transform_log' message
+    // so start sending immediately
+    if (this.settings.live) {
+      this.sendPlayResp({});
+    }
   }
 
   onClose(event) {
@@ -314,8 +324,8 @@ class ConnectionContext {
         // TODO: support choosing log here
         break;
       case 'xviz/transform_log': {
-        this.log(`| ts: ${msg.timestamp} duration: ${msg.duration}`);
-        this.sendPlayResp(msg);
+        this.log(`| start: ${msg.data.start_timestamp} end: ${msg.data.end_timestamp}`);
+        this.sendPlayResp(msg.data);
         break;
       }
       default:
@@ -393,7 +403,7 @@ class ConnectionContext {
   }
 
   sendMetadata() {
-    const frame = getFrameData(this.metadata);
+    const frame = this._loadFrameData(this.metadata);
     const isBuffer = frame instanceof Buffer;
 
     const frame_send_time = process.hrtime();
@@ -437,7 +447,7 @@ class ConnectionContext {
 
     // get frame info
     const frame_index = getFrameIndex(ii, frames.length);
-    const frame = getFrameData(frames[frame_index]);
+    const frame = this._loadFrameData(frames[frame_index]);
 
     // TODO images are not supported here, but glb data is
     // old image had a binary header
@@ -508,10 +518,10 @@ class ConnectionContext {
 
 // Comms handling
 
-function setupWebSocketHandling(wss, settings, metadata, frames, frameTiming) {
+function setupWebSocketHandling(wss, settings, metadata, frames, frameTiming, loadFrameData) {
   // Setups initial connection state
   wss.on('connection', ws => {
-    const context = new ConnectionContext(settings, metadata, frames, frameTiming);
+    const context = new ConnectionContext(settings, metadata, frames, frameTiming, loadFrameData);
     context.onConnection(ws);
   });
 }
@@ -519,8 +529,17 @@ function setupWebSocketHandling(wss, settings, metadata, frames, frameTiming) {
 // Main
 
 module.exports = function main(args) {
-  console.log(`Loading frames from ${args.data_directory}`);
-  const frames = loadFrames(args.data_directory);
+  const runScenario = args.scenario.length > 0;
+
+  if (runScenario) {
+    console.log(`Loading frames for scenario ${args.scenario}`);
+  } else {
+    console.log(`Loading frames from ${args.data_directory}`);
+  }
+
+  const frames = runScenario
+    ? loadScenario(args.scenario, args.live, args.duration)
+    : loadFrames(args.data_directory);
 
   if (frames.frames.length === 0) {
     console.error('No frames where loaded, exiting.');
@@ -528,7 +547,7 @@ module.exports = function main(args) {
   }
 
   // Try to load from and timing index
-  let frameTiming = loadTimingIndex(args.data_directory);
+  let frameTiming = runScenario ? frames.timing : loadTimingIndex(args.data_directory);
   const frameTimingValue = frameTiming.length === frames.frames.length;
 
   if (!frameTiming || !frameTimingValue) {
@@ -544,6 +563,7 @@ module.exports = function main(args) {
   console.log(`Loaded ${frames.frames.length} frames`);
 
   const settings = {
+    live: args.live,
     duration: args.duration,
     send_interval: args.delay,
     skip_images: args.skip_images,
@@ -551,5 +571,12 @@ module.exports = function main(args) {
   };
 
   const wss = new WebSocket.Server({port: args.port});
-  setupWebSocketHandling(wss, settings, frames.metadata, frames.frames, frameTiming);
+  setupWebSocketHandling(
+    wss,
+    settings,
+    frames.metadata,
+    frames.frames,
+    frameTiming,
+    runScenario ? x => x : getFrameData
+  );
 };


### PR DESCRIPTION
The scenarios are dynamically generated XVIZ supporting arbitrary
durations for testing long running sessions.

Start a 10 minutes live XVIZ server session using the circle scenario
`node index.js --scenario=circle --live --duration 600`

Start the streetscape.gl example app PR #202
`yarn start-live-local`

- add `--scenario` option to XVIZ server
  - options are 'circle' and 'straight'
- add `--live` to support sending XVIZ data upon connection
- fix 'tranform_log' message parameter handling
- fix and clarify time units in options