### PR TITLE
Add check for array with length of 1 in getCentroid

### DIFF
--- a/modules/parser/src/utils/geometry.js
+++ b/modules/parser/src/utils/geometry.js
@@ -5,6 +5,10 @@ export function getCentroid(polygon) {
   let sz = 0;
 
   let len = polygon.length;
+  if (len === 1) {
+    return polygon[0];
+  }
+
   if (polygon[0] === polygon[len - 1]) {
     // the last vertex is the same as the first, ignore
     len -= 1;

--- a/test/modules/parser/objects/xviz-object.spec.js
+++ b/test/modules/parser/objects/xviz-object.spec.js
@@ -64,5 +64,9 @@ test('XVIZObject#_reset, _addFeature, isValid', t => {
   object._addFeature('/c', {vertices: [[0, 1], [1, 2]]});
   t.deepEquals(object.position, [0, 1, 2], 'prefers point geometry over polygons');
 
+  object._reset();
+  object._addFeature('/a', {vertices: [[0, 1]]});
+  t.deepEquals(object.position, [0, 1], 'valid position if array has a single point');
+
   t.end();
 });


### PR DESCRIPTION
There are cases where an array with 1 point can be passed in
, where the type of an object is manually changed from point to circle,
and the check for first point matching last point results in division
by zero.

Fixed by checking for a length of 1 first.