### PR TITLE
log-synchronizer should handle an empty entry in a stream

### DIFF
--- a/modules/parser/src/parsers/parse-xviz-stream.js
+++ b/modules/parser/src/parsers/parse-xviz-stream.js
@@ -36,7 +36,13 @@ export function parseXVIZStream(data, convertPrimitive) {
   // Each object is [{primitives, variables, timestamp},...]
   // Each object represents a timestamp and array of objects
 
+  // V1 has a no-data entry that results in setting all top-level types to an
+  // empty array. See the test cases.
+  //
+  // Usually only one of these fields is valid and thus only one is normally
+  // iterated below.
   const {primitives, ui_primitives, variables, futures} = data[0];
+
   // At this point, we either have one or the other.
   // TODO(twojtasz): BUG: there is an assumption that
   // streamNames will be unique.  Need to put in a detection if
@@ -258,7 +264,7 @@ export function parseStreamVariable(objects, streamName, time) {
 
 export function parseStreamVariableV1(objects, streamName, time) {
   if (Array.isArray(objects)) {
-    return {};
+    return {time};
   }
 
   let variable;
@@ -281,7 +287,7 @@ export function parseStreamVariableV1(objects, streamName, time) {
 
 export function parseStreamVariableV2(objects, streamName, time) {
   if (Array.isArray(objects)) {
-    return {};
+    return {time};
   }
 
   const variables = objects.variables;

--- a/modules/parser/src/synchronizers/log-synchronizer.js
+++ b/modules/parser/src/synchronizers/log-synchronizer.js
@@ -57,8 +57,9 @@ export default class LogSynchronizer extends BaseSynchronizer {
    * Find and process stream data in the range (start, end] for process
    * Returns a list of streams sorted by decending time
    *
-   * Since we have all samples and can find the exact datum for the stream i
-   * there is no "range" of samples to process and the reverse ordering does not apply.
+   * Since we have all samples and can find the correct datum for every stream
+   * and only send back an array of 1 element. To do this we will apply the
+   * reverse search here, stopping when we find the entry closest to endTime.
    *
    * @param Number startTime - The time to start from.
    * @param Number endTime - The time to end at.
@@ -101,28 +102,34 @@ export default class LogSynchronizer extends BaseSynchronizer {
     }
 
     const startIndex = log.index || 0;
+    let endIndex = null;
+    let endTimestamp;
+
     // invalidate
     log.index = null;
 
+    // Find the range of indices for the given start and end time
     for (let i = startIndex; i < log.data.length; ++i) {
       const timestamp = this._getTimeFromObject(log.data[i]);
-
       // If timestamp < startTime, sample before our target window, so don't update index
       if (timestamp > startTime && timestamp <= endTime) {
         // Within our target window, so update index
-        log.index = i;
-        log.time = timestamp;
+        endIndex = i;
+        endTimestamp = timestamp;
       } else if (timestamp > endTime) {
         // Beyond our target window, so exit early
         break;
-      } else if (timestamp === undefined) {
-        // We have an empty object which signals a non-data entry
-        log.time = 0;
-        log.index = null;
       }
     }
 
-    return log.index === null ? null : log.data[log.index];
+    // Found no entry
+    if (endIndex === null) {
+      return null;
+    }
+
+    log.index = endIndex;
+    log.time = endTimestamp;
+    return log.data[endIndex];
   }
 
   _getTimeFromObject(object) {


### PR DESCRIPTION
- Empty entries mean we should stop looking back for a valid entry
  That is, an empty entry means there is no data, so don't show
  stale data from later in time