### PR TITLE
Make XVIZ cli gracefully handle shutdown

### DIFF
--- a/modules/cli/src/cmds/validate.js
+++ b/modules/cli/src/cmds/validate.js
@@ -58,15 +58,26 @@ export function command(args) {
 
   const validator = new XVIZSessionValidator(options);
 
+  let printed = false;
+  const printSummary = () => {
+    if (!printed) {
+      printErrorSummary(validator.stats, args);
+      printed = false;
+    }
+  };
+
   // Report validation as we go
   const reportValidation = {
     onMetadata: msg => {
       if (args.metadata) {
-        printErrorSummary(validator.stats, args);
+        printSummary();
       }
     },
     onTransformLogDone: msg => {
-      printErrorSummary(validator.stats, args);
+      printSummary();
+    },
+    onClose: () => {
+      printSummary();
     }
   };
 

--- a/modules/cli/src/connect.js
+++ b/modules/cli/src/connect.js
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-env node */
+/* eslint no-console: ["error", { allow: ["log"] }] */
+
 import {XVIZMiddlewareStack} from './middleware';
 import {WebSocketInterface} from './websocket';
 import {TransformLogFlow, OnlyMetadata} from './core';
@@ -48,6 +51,21 @@ export function openSource(args, middlewares) {
       middleware.client = client;
     }
   }
+
+  // Setup graceful shutdown
+  let sigintCount = 0;
+  process.on('SIGINT', () => {
+    if (sigintCount === 0) {
+      console.log('Closing');
+      socket.close();
+    } else {
+      // If the user or system is really mashing Ctrl-C, then abort
+      console.log('Aborting');
+      process.exit(1); // eslint-disable-line no-process-exit
+    }
+
+    sigintCount++;
+  });
 
   return client;
 }


### PR DESCRIPTION
Some XVIZ services are continously stream data and you just want to
have a peak.  This closes the websocket connection on Ctrl-C then
prints out the latest error summary information.

If things are really pear shaped multiple Ctrl-C will just abort
the application like normal.