### PR TITLE
Example conformance tests

### DIFF
--- a/examples/server/args.js
+++ b/examples/server/args.js
@@ -22,7 +22,8 @@ const parser = new ArgumentParser({
 });
 
 parser.addArgument(['-d', '--data_directory'], {
-  help: 'Directory to serve data from. Relative path will be resolved relative to /data/generated/'
+  help:
+    'Directory to serve data from. Relative path will be resolved relative to /data/generated/, and absolute paths directly.'
 });
 
 parser.addArgument(['--port'], {
@@ -73,7 +74,9 @@ parser.addArgument(['--skip_images'], {
 module.exports = function getArgs() {
   const args = parser.parseArgs();
   if (args.data_directory) {
-    args.data_directory = path.resolve(__dirname, '../../data/generated/', args.data_directory);
+    if (!args.data_directory.startsWith('/')) {
+      args.data_directory = path.resolve(__dirname, '../../data/generated/', args.data_directory);
+    }
   }
 
   return args;

--- a/examples/server/xviz-serve-data.js
+++ b/examples/server/xviz-serve-data.js
@@ -174,7 +174,9 @@ function loadFrameTimings(frames) {
 // Determine the actual index into frames when looping over data repeatedly
 // Happens when frame_limit > framesLength
 function getFrameIndex(index, framesLength) {
-  if (index >= framesLength) {
+  if (framesLength === 1) {
+    return 0;
+  } else if (index >= framesLength) {
     // do not include count metadata
     const xviz_count = framesLength - 1;
 
@@ -301,6 +303,7 @@ class ConnectionContext {
     // Used to manage changing an inflight request
     this.replaceFrameRequest = null;
     this.inflight = false;
+    this.transformId = '';
 
     this.onConnection.bind(this);
     this.onClose.bind(this);
@@ -342,6 +345,7 @@ class ConnectionContext {
         break;
       case 'xviz/transform_log': {
         this.log(`| start: ${msg.data.start_timestamp} end: ${msg.data.end_timestamp}`);
+        this.transformId = msg.data.id;
         this.sendPlayResp(msg.data);
         break;
       }
@@ -489,7 +493,7 @@ class ConnectionContext {
       } else {
         // When last_index reached send 'transform_log_done' message
         if (!this.settings.live) {
-          this.sendEnveloped('transform_log_done', {}, {}, () => {
+          this.sendEnveloped('transform_log_done', {id: this.transformId}, {}, () => {
             this.logMsgSent(frame_send_time, -1, frame_index, 'json');
           });
         }

--- a/modules/cli/src/cmds/validate.js
+++ b/modules/cli/src/cmds/validate.js
@@ -62,7 +62,7 @@ export function command(args) {
   const printSummary = () => {
     if (!printed) {
       printErrorSummary(validator.stats, args);
-      printed = false;
+      printed = true;
     }
   };
 

--- a/modules/conformance/inputs/circle/style/1-frame.json
+++ b/modules/conformance/inputs/circle/style/1-frame.json
@@ -1,0 +1,61 @@
+{
+  "type": "xviz/metadata",
+  "data": {
+    "version": "2.0.0",
+    "streams": {
+      "/vehicle_pose": {
+        "category": "pose"
+      },
+
+      "/circle/inline/radius": {
+        "category": "primitive",
+        "primitive_type": "circle",
+        "coordinate": "VEHICLE_RELATIVE"
+      },
+
+      "/circle/inline/fill_color": {
+        "category": "primitive",
+        "primitive_type": "circle",
+        "coordinate": "VEHICLE_RELATIVE"
+      },
+
+      "/circle/stream/fill_color": {
+        "category": "primitive",
+        "primitive_type": "circle",
+        "coordinate": "VEHICLE_RELATIVE",
+        "stream_style": {
+          "fill_color": "#f00",
+          "stroke_width": 0,
+          "radius": 1
+        }
+      },
+
+      "/circle/stream/radius_min_pixel": {
+        "category": "primitive",
+        "primitive_type": "circle",
+        "coordinate": "VEHICLE_RELATIVE",
+        "stream_style": {
+          "radius_min_pixels": 50,
+          "fill_color": "#00f"
+        }
+      },
+
+      "/circle/stream/radius_max_pixels": {
+        "category": "primitive",
+        "primitive_type": "circle",
+        "coordinate": "VEHICLE_RELATIVE",
+        "stream_style": {
+          "radius_max_pixels": 100,
+          "fill_color": "#00f"
+        }
+      }
+
+    },
+    "log_info": {
+      "description": "XVIZ Client Test - Circle Styling",
+      "license": "Apache 2.0",
+      "start_time": 1000,
+      "end_time": 1010
+    }
+  }
+}

--- a/modules/conformance/inputs/circle/style/2-frame.json
+++ b/modules/conformance/inputs/circle/style/2-frame.json
@@ -1,0 +1,81 @@
+{
+  "type": "xviz/state_update",
+  "data": {
+    "update_type": "snapshot",
+    "updates": [
+      {
+        "timestamp": 1000.1,
+        "poses": {
+          "/vehicle_pose": {
+            "timestamp": 1000.1,
+            "orientation": [0, 0, 0],
+            "position": [0, 0, 0],
+            "mapOrigin": {
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "altitude": 0
+            }
+          }
+        },
+        "primitives": {
+
+          "/circle/inline/radius": {
+            "circles": [
+              {
+                "center": [10, 10, 0],
+                "radius_m": 1.0,
+                "base": {
+                  "inline_style": {
+                    "radius": 5
+                  }
+                }
+              }
+            ]
+          },
+
+          "/circle/inline/fill_color": {
+            "circles": [
+              {
+                "center": [10, -10, 0],
+                "radius_m": 1.0,
+                "base": {
+                  "inline_style": {
+                    "fill_color": "#0f0"
+                  }
+                }
+              }
+            ]
+          },
+
+          "/circle/stream/fill_color": {
+            "circles": [
+              {
+                "center": [-10, 10, 0],
+                "radius_m": 1.0
+              }
+            ]
+          },
+
+          "/circle/stream/radius_min_pixels": {
+            "circles": [
+              {
+                "center": [-10, -10, 0],
+                "radius_m": 1.0
+              }
+            ]
+          },
+
+          "/circle/stream/radius_max_pixels": {
+            "circles": [
+              {
+                "center": [-15, -25, 0],
+                "radius_m": 1.0
+              }
+            ]
+          }
+
+        }
+      }
+    ]
+  }
+}

--- a/modules/conformance/inputs/circle/style/README.md
+++ b/modules/conformance/inputs/circle/style/README.md
@@ -1,0 +1,3 @@
+# Broken
+- inline fill color does not work
+- radius_m appears ignored

--- a/modules/conformance/inputs/point/style/1-frame.json
+++ b/modules/conformance/inputs/point/style/1-frame.json
@@ -1,0 +1,39 @@
+{
+  "type": "xviz/metadata",
+  "data": {
+    "version": "2.0.0",
+    "streams": {
+      "/vehicle_pose": {
+        "category": "pose"
+      },
+
+      "/point/inline/radius": {
+        "category": "primitive",
+        "primitive_type": "point",
+        "coordinate": "VEHICLE_RELATIVE"
+      },
+
+      "/point/inline/fill_color": {
+        "category": "primitive",
+        "primitive_type": "point",
+        "coordinate": "VEHICLE_RELATIVE"
+      },
+
+      "/point/stream/fill_color": {
+        "category": "primitive",
+        "primitive_type": "point",
+        "coordinate": "VEHICLE_RELATIVE",
+        "stream_style": {
+          "fill_color": "#f00"
+        }
+      }
+
+    },
+    "log_info": {
+      "description": "XVIZ Client Test - Point Styling",
+      "license": "Apache 2.0",
+      "start_time": 1000,
+      "end_time": 1010
+    }
+  }
+}

--- a/modules/conformance/inputs/point/style/2-frame.json
+++ b/modules/conformance/inputs/point/style/2-frame.json
@@ -1,0 +1,60 @@
+{
+  "type": "xviz/state_update",
+  "data": {
+    "update_type": "snapshot",
+    "updates": [
+      {
+        "timestamp": 1000.1,
+        "poses": {
+          "/vehicle_pose": {
+            "timestamp": 1000.1,
+            "orientation": [0, 0, 0],
+            "position": [0, 0, 0],
+            "mapOrigin": {
+              "longitude": -122.4,
+              "latitude": 37.8,
+              "altitude": 0
+            }
+          }
+        },
+        "primitives": {
+
+          "/point/inline/radius": {
+            "points": [
+              {
+                "points": [[10, 10, 0]],
+                "base": {
+                  "inline_style": {
+                    "radius": 5
+                  }
+                }
+              }
+            ]
+          },
+
+          "/point/inline/fill_color": {
+            "points": [
+              {
+                "points": [[10, -10, 0]],
+                "base": {
+                  "inline_style": {
+                    "fill_color": "#0f0"
+                  }
+                }
+              }
+            ]
+          },
+
+          "/point/stream/fill_color": {
+            "points": [
+              {
+                "points": [[-10, 10, 0]]
+              }
+            ]
+          }
+
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
These are valid single update XVIZ logs that demonstrate rendering XVIZ
rendering features.  The is the start of the first pass that will validate
the rendering layer.

The example server is also fixed so that it can render these examples when
you supply and absolute path to them.

In addition we sneak a fix for the validation summary view so you can
test by doing:

    node ./examples/server/index.js -d ~/code/xviz/modules/conformance/inputs/point/style

Then checking the validity (metadata is a spec bug, start is a bug
in the request stack):

```
$ ./modules/cli/bin/babel-xviz validate -c ws://localhost:8081 .
┌────────────────────┬───────┬─────────┬───────┬───────────────┐
│ Type               │ Count │ Invalid │ Inv % │ Unique Errors │
├────────────────────┼───────┼─────────┼───────┼───────────────┤
│ START              │ 1     │ 1       │ 100.0 │ 1             │
├────────────────────┼───────┼─────────┼───────┼───────────────┤
│ METADATA           │ 1     │ 1       │ 100.0 │ 1             │
├────────────────────┼───────┼─────────┼───────┼───────────────┤
│ TRANSFORM_LOG      │ 1     │ 0       │ 0.0   │ 0             │
├────────────────────┼───────┼─────────┼───────┼───────────────┤
│ STATE_UPDATE       │ 1     │ 0       │ 0.0   │ 0             │
├────────────────────┼───────┼─────────┼───────┼───────────────┤
│ TRANSFORM_LOG_DONE │ 1     │ 0       │ 0.0   │ 0             │
└────────────────────┴───────┴─────────┴───────┴───────────────┘
```