### PR TITLE
Allow sending nested JSON string to parseStreamMessage

### DIFF
--- a/docs/overview/ros-comparison.md
+++ b/docs/overview/ros-comparison.md
@@ -6,8 +6,8 @@ visualization stack. While XVIZ is a protocol, and eventually an ecosystem, for 
 systems.
 
 XVIZ goals are more focused than ROS. It's designed to create a standard protocol that allows
-innovative clients to be built, offload expensive data transformations to a server, and minimize data
-sent to the client. Doing for robotics what HTML and MP4 do for video and multi-media content.
+innovative clients to be built, offload expensive data transformations to a server, and minimize
+data sent to the client. Doing for robotics what HTML and MP4 do for video and multi-media content.
 
 On our [roadmap](/docs/overview/roadmap.md) is a plan to bridge these worlds by updating our example
 XVIZ server to support realtime conversion of ROS's [bag](http://wiki.ros.org/Bags) log format and

--- a/modules/parser/src/parsers/parse-stream-data-message.js
+++ b/modules/parser/src/parsers/parse-stream-data-message.js
@@ -55,7 +55,7 @@ function decode(data, recursive) {
     const jsonString = new TextDecoder('utf8').decode(data);
     return JSON.parse(jsonString);
   } else if (typeof data === 'string' && isJSONString(data)) {
-    return data;
+    return JSON.parse(data);
   } else if (recursive && typeof data === 'object') {
     for (const key in data) {
       // Only peek one-level deep
@@ -92,7 +92,6 @@ export function parseStreamDataMessage(message, onResult, onError, opts) {
 
   try {
     let data = decode(message, true);
-
     let v2Type;
     let parseData = true;
     if (isEnvelope(data)) {

--- a/test/bench/xviz.bench.js
+++ b/test/bench/xviz.bench.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* global Buffer */
+/* eslint-disable camelcase */
 import sampleXVIZMetadata from 'test-data/sample-metadata-message.json';
 import sampleXVIZSnapshot from 'test-data/sample-xviz.json';
 import sampleXVIZStylesheet from 'test-data/xviz-style-sheet.json';
@@ -39,10 +41,29 @@ function parse(message, opts) {
   return result;
 }
 
+const getBuffer = xvizString => {
+  const buf = new Buffer(xvizString);
+  const length = buf.byteLength / Uint8Array.BYTES_PER_ELEMENT;
+  return new Uint8Array(buf.buffer, buf.byteOffset, length);
+};
+const xvizTestString = JSON.stringify(sampleXVIZSnapshot.updates);
+const xvizTestBuffer = getBuffer(xvizTestString);
+const stringTestJSON = {
+  update_type: sampleXVIZSnapshot.update_type,
+  updates: xvizTestString
+};
+
+const binaryTestJSON = {
+  update_type: sampleXVIZSnapshot.update_type,
+  updates: xvizTestBuffer
+};
+
 export default function xvizBench(bench) {
   return bench
     .group('PARSE XVIZ')
     .add('xviz#parseMetadata', () => parse(sampleXVIZMetadata))
     .add('xviz#parseFrame', () => parse(sampleXVIZSnapshot))
+    .add('xviz#parseFrame_StringJSON', () => parse(stringTestJSON))
+    .add('xviz#parseFrame_BinaryJSON', () => parse(binaryTestJSON))
     .add('xviz#parseStylesheet', () => new XVIZStyleParser(sampleXVIZStylesheet));
 }


### PR DESCRIPTION
Fix issue in https://github.com/uber/xviz/issues/335

**Why**
when we send the data to `parseStreamMessage` in the shape of JSON or Uint8Array, and when web worker is used, the data is mutated when we are using webworker.
The goal is to save a snapshot of data that can't be mutated (string) and has minimal perf impact.

**What is in the PR**
1. Move JSON.parse to decode and decode is called recursively. Now the parser supports JSON in this shape:

```
{
  type: 'snapshot',
  updates: '//xviz string that can be sent to JSON.parse'
}
```
2. Added Bench tests for additional data shapes as described in 2.

**No Significant Performance impact**

_Bench results with this fix branch_
We can see that the text-encoder has minimal impact on performance.
![screen shot 2019-02-20 at 12 54 56 pm](https://user-images.githubusercontent.com/5092813/53124413-28193400-3510-11e9-8350-40b8f0a10056.png)


_Bench on master_
![screen shot 2019-02-20 at 12 35 48 pm](https://user-images.githubusercontent.com/5092813/53122718-20579080-350c-11e9-8ab3-519f8ced1be3.png)
