### PR TITLE
Disable server with both loop and scenario options

### DIFF
--- a/examples/server/xviz-serve-data.js
+++ b/examples/server/xviz-serve-data.js
@@ -700,6 +700,13 @@ function packFrame({json, isBinary}) {
 module.exports = function main(args) {
   const runScenario = args.scenario.length > 0;
 
+  // Until scenarios generate data in a way that is compatible with
+  // looping catch this directly for users.
+  if (args.loop && args.scenario) {
+    console.error('Error: --loop not compatible with --scenario');
+    process.exit(1);
+  }
+
   if (runScenario) {
     console.log(`Loading frames for scenario ${args.scenario}`);
   } else {


### PR DESCRIPTION
These are not currently compatible and we should provide the users a
clear error message until the point they are actually compatible.