### PR TITLE
Point XVIZStyleParser API doc to the right md file

### DIFF
--- a/website/pages.json
+++ b/website/pages.json
@@ -257,7 +257,7 @@
           },
           {
             "name": "XVIZStyleParser",
-            "markdown": "api-reference/xviz-stream-buffer.md"
+            "markdown": "api-reference/xviz-style-parser.md"
           },
           {
             "name": "XVIZObject",


### PR DESCRIPTION
Fix #359.