### PR TITLE
Remove loResTime logic in base synchronizer

### DIFF
--- a/modules/parser/src/synchronizers/base-synchronizer.js
+++ b/modules/parser/src/synchronizers/base-synchronizer.js
@@ -60,7 +60,6 @@ export default class BaseSynchronizer {
     this.opts = opts;
 
     this.time = 0;
-    this.loResTime = 0;
     this.lookAheadMs = 0;
   }
 
@@ -97,19 +96,12 @@ export default class BaseSynchronizer {
     return this.time;
   }
 
-  // The low resolution time is rounded to bigger intervals, throttling updates
-  getLoResTime() {
-    return this.loResTime;
-  }
-
   /**
    * @param {Number} time - time to synchronize the logs with
    * @return {StreamSynchronizer} - returns itself for chaining.
    */
   setTime(time) {
-    const {PLAYBACK_FRAME_RATE} = getXVIZConfig();
     this.time = time;
-    this.loResTime = Math.round(time * PLAYBACK_FRAME_RATE) / PLAYBACK_FRAME_RATE;
     assert(Number.isFinite(this.time), 'Invalid time');
     return this;
   }
@@ -138,10 +130,9 @@ export default class BaseSynchronizer {
 
     // Find the right timeslices
     const {TIME_WINDOW} = getXVIZConfig();
-    this._lastLoResTime = this.loResTime;
     this._streamsByReverseTime = this._getTimeRangeInReverse(
-      this.loResTime - TIME_WINDOW,
-      this.loResTime
+      this.time - TIME_WINDOW,
+      this.time
     );
     xvizStats.bump('geometry-refresh');
 


### PR DESCRIPTION
As discussed, the loResTime logic should be moved to the loader or each appliation.
How we test: Unit Test; and Manually verify there is no usage of `loResTime` in streetscape.
