### PR TITLE
Update docker tests to newer version of Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Docker Image for BuildKite CI
 # -----------------------------
 
-FROM node:8.11.4
+FROM node:10.15.3
 
 RUN yarn global add yarn@1.10.0
 


### PR DESCRIPTION
This will be based on a supported version of debian and fix the Buildkite errors.