### PR TITLE
Optionally cap the number of worker messages that can queue

### DIFF
--- a/docs/api-reference/parse-xviz.md
+++ b/docs/api-reference/parse-xviz.md
@@ -34,6 +34,8 @@ Parameters:
     - string: a custom worker URL to use.
   - `maxConcurrency` (Number) - the max number of workers to use. Has no effect if `worker` is set
     to `false`. Default `4`.
+  - `capacity` (Number) - the limit on the number of messages to queue for the workers to process,
+    has no effect if set ot `null`. Default `null`.
 
 ##### LOG_STREAM_MESSAGE
 

--- a/modules/parser/src/parsers/parse-stream-message.js
+++ b/modules/parser/src/parsers/parse-stream-message.js
@@ -17,8 +17,8 @@ import {postDeserialize} from './serialize';
 import {getWorkerFarm, initializeWorkerFarm} from './parse-stream-workerfarm';
 
 // Public function for initializing workers
-export function initializeWorkers({worker, maxConcurrency = 4}) {
-  initializeWorkerFarm({worker, maxConcurrency});
+export function initializeWorkers({worker, maxConcurrency = 4, capacity = null}) {
+  initializeWorkerFarm({worker, maxConcurrency, capacity});
 }
 
 export function parseStreamMessage({
@@ -29,11 +29,12 @@ export function parseStreamMessage({
   debug,
   // worker options
   worker = false,
-  maxConcurrency = 4
+  maxConcurrency = 4,
+  capacity = null
 }) {
   if (worker) {
     if (!getWorkerFarm()) {
-      initializeWorkers({worker, maxConcurrency});
+      initializeWorkers({worker, maxConcurrency, capacity});
     }
 
     const workerFarm = getWorkerFarm();

--- a/modules/parser/src/parsers/parse-stream-workerfarm.js
+++ b/modules/parser/src/parsers/parse-stream-workerfarm.js
@@ -31,7 +31,7 @@ export function destroyWorkerFarm() {
   }
 }
 
-export function initializeWorkerFarm({worker, maxConcurrency = 4}) {
+export function initializeWorkerFarm({worker, maxConcurrency = 4, capacity = null}) {
   if (!workerFarm) {
     const xvizConfig = {...getXVIZConfig()};
     delete xvizConfig.preProcessPrimitive;
@@ -49,6 +49,7 @@ export function initializeWorkerFarm({worker, maxConcurrency = 4}) {
     workerFarm = new WorkerFarm({
       workerURL,
       maxConcurrency,
+      capacity,
       initialMessage: {xvizConfig}
     });
   }


### PR DESCRIPTION
When processing data in real time if you fall behind the queue can
grow unbounded, so you need the ability to cap it.