### PR TITLE
Enable flattened arrays

### DIFF
--- a/examples/converters/kitti/src/parsers/parse-lidar-points.js
+++ b/examples/converters/kitti/src/parsers/parse-lidar-points.js
@@ -37,18 +37,14 @@ export function loadLidarData(data) {
   const size = Math.round(binary.length / 4);
 
   // We could return interleaved buffers, no conversion!
-  const positions = new Float32Array(3 * size);
-  const colors = new Uint8Array(4 * size).fill(255);
+  const positions = new Array(size);
+  const colors = new Array(size);
 
   for (let i = 0; i < size; i++) {
-    positions[i * 3 + 0] = float[i * 4 + 0];
-    positions[i * 3 + 1] = float[i * 4 + 1];
-    positions[i * 3 + 2] = float[i * 4 + 2];
+    positions[i] = float.subarray(i * 4, i * 4 + 3);
 
     const reflectance = Math.min(float[i * 4 + 3], 3);
-    colors[i * 4 + 0] = 80 + reflectance * 80;
-    colors[i * 4 + 1] = 80 + reflectance * 80;
-    colors[i * 4 + 2] = 80 + reflectance * 60;
+    colors[i] = [80 + reflectance * 80, reflectance * 80, reflectance * 60];
   }
   return {positions, colors};
 }

--- a/modules/builder/src/utils/flatten.js
+++ b/modules/builder/src/utils/flatten.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export function flattenToTypedArray(nestedArray, ArrayType = Float32Array) {
+export function flattenToTypedArray(nestedArray, dimensions = 3, ArrayType = Float32Array) {
   if (nestedArray.length === 0) {
     return new Float32Array(0);
   }
@@ -21,10 +21,10 @@ export function flattenToTypedArray(nestedArray, ArrayType = Float32Array) {
     return null;
   }
 
-  const count = countVertices(nestedArray);
+  const count = countVertices(nestedArray, dimensions);
 
   const typedArray = new ArrayType(count);
-  flattenVerticesInPlace(nestedArray, typedArray);
+  flattenVerticesInPlace(nestedArray, typedArray, dimensions);
   return typedArray;
 }
 

--- a/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
@@ -69,7 +69,8 @@ function flattenObject(key, object) {
     return flattenToTypedArray(object, 3, Float32Array);
   }
   if (key === 'colors') {
-    return flattenToTypedArray(object, 4, Uint8Array);
+    const size = object[0].length === 4 ? 4 : 3;
+    return flattenToTypedArray(object, size, Uint8Array);
   }
   return null;
 }

--- a/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
@@ -14,13 +14,13 @@
 
 import {flattenToTypedArray} from '../../utils';
 
-function packBinaryJsonTypedArray(gltfBuilder, object, objectKey) {
+function packBinaryJsonTypedArray(gltfBuilder, object, objectKey, info) {
   if (gltfBuilder.isImage(object)) {
     const imageIndex = gltfBuilder.addImage(object);
     return `#/images/${imageIndex}`;
   }
   // if not an image, pack as accessor
-  const opts = objectKey === 'colors' ? {size: 4} : {size: 3};
+  const opts = info && info.size ? {size: info.size} : {size: 3};
   const bufferIndex = gltfBuilder.addBuffer(object, opts);
   return `#/accessors/${bufferIndex}`;
 }
@@ -31,6 +31,7 @@ function packBinaryJsonTypedArray(gltfBuilder, object, objectKey) {
 export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}) {
   const {flattenArrays = true} = options;
   let object = json;
+  let objectInfo = null;
 
   // Check if string has same syntax as our "JSON pointers", if so "escape it".
   if (typeof object === 'string' && object.indexOf('#/') === 0) {
@@ -39,9 +40,10 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
 
   if (Array.isArray(object)) {
     // TODO - handle numeric arrays, flatten them etc.
-    const typedArray = flattenArrays && flattenObject(objectKey, object);
-    if (typedArray) {
-      object = typedArray;
+    const flatObject = flattenArrays && flattenObject(objectKey, object);
+    if (flatObject) {
+      object = flatObject.typedArray;
+      objectInfo = flatObject;
     } else {
       return object.map(element => packBinaryJson(element, gltfBuilder, options));
     }
@@ -49,7 +51,7 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
 
   // Typed arrays, pack them as binary
   if (ArrayBuffer.isView(object) && gltfBuilder) {
-    return packBinaryJsonTypedArray(gltfBuilder, object, objectKey);
+    return packBinaryJsonTypedArray(gltfBuilder, object, objectKey, objectInfo);
   }
 
   if (object !== null && typeof object === 'object') {
@@ -66,11 +68,17 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
 function flattenObject(key, object) {
   if (key === 'vertices' || key === 'points') {
     // Flatten nested vertices
-    return flattenToTypedArray(object, 3, Float32Array);
+    return {
+      typedArray: flattenToTypedArray(object, 3, Float32Array),
+      size: 3
+    };
   }
   if (key === 'colors') {
     const size = object[0].length === 4 ? 4 : 3;
-    return flattenToTypedArray(object, size, Uint8Array);
+    return {
+      typedArray: flattenToTypedArray(object, size, Uint8Array),
+      size
+    };
   }
   return null;
 }

--- a/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
@@ -28,9 +28,9 @@ function packBinaryJsonTypedArray(gltfBuilder, object, objectKey) {
 // Follows a convention used by @loaders.gl to use JSONPointers
 // to encode where the binary data for a XVIZ element resides.
 // The unpacking is handled automatically by @loaders.gl
+// eslint-disable-next-line complexity
 export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}) {
   const {flattenArrays = true} = options;
-  console.log(flattenArrays);
   let object = json;
 
   // Check if string has same syntax as our "JSON pointers", if so "escape it".
@@ -39,11 +39,12 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
   }
 
   if (Array.isArray(object)) {
-    // TODO - handle numeric arrays, flatten them etc.
-    console.log(flattenArrays);
-    const typedArray = flattenArrays && flattenToTypedArray(object);
-    if (typedArray) {
-      object = typedArray;
+    if (Number.isFinite(object[0])) {
+      return object;
+    }
+    if (flattenArrays && Array.isArray(object[0])) {
+      // Flatten nested vertices
+      object = flattenToTypedArray(object);
     } else {
       return object.map(element => packBinaryJson(element, gltfBuilder, options));
     }

--- a/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
@@ -28,7 +28,6 @@ function packBinaryJsonTypedArray(gltfBuilder, object, objectKey) {
 // Follows a convention used by @loaders.gl to use JSONPointers
 // to encode where the binary data for a XVIZ element resides.
 // The unpacking is handled automatically by @loaders.gl
-// eslint-disable-next-line complexity
 export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}) {
   const {flattenArrays = true} = options;
   let object = json;
@@ -39,12 +38,10 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
   }
 
   if (Array.isArray(object)) {
-    if (Number.isFinite(object[0])) {
-      return object;
-    }
-    if (flattenArrays && Array.isArray(object[0])) {
-      // Flatten nested vertices
-      object = flattenToTypedArray(object);
+    // TODO - handle numeric arrays, flatten them etc.
+    const typedArray = flattenArrays && flattenObject(objectKey, object);
+    if (typedArray) {
+      object = typedArray;
     } else {
       return object.map(element => packBinaryJson(element, gltfBuilder, options));
     }
@@ -64,4 +61,15 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
   }
 
   return object;
+}
+
+function flattenObject(key, object) {
+  if (key === 'vertices' || key === 'points') {
+    // Flatten nested vertices
+    return flattenToTypedArray(object, 3, Float32Array);
+  }
+  if (key === 'colors') {
+    return flattenToTypedArray(object, 4, Uint8Array);
+  }
+  return null;
 }

--- a/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
@@ -29,7 +29,8 @@ function packBinaryJsonTypedArray(gltfBuilder, object, objectKey) {
 // to encode where the binary data for a XVIZ element resides.
 // The unpacking is handled automatically by @loaders.gl
 export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}) {
-  const {flattenArrays = false} = options;
+  const {flattenArrays = true} = options;
+  console.log(flattenArrays);
   let object = json;
 
   // Check if string has same syntax as our "JSON pointers", if so "escape it".
@@ -39,6 +40,7 @@ export function packBinaryJson(json, gltfBuilder, objectKey = null, options = {}
 
   if (Array.isArray(object)) {
     // TODO - handle numeric arrays, flatten them etc.
+    console.log(flattenArrays);
     const typedArray = flattenArrays && flattenToTypedArray(object);
     if (typedArray) {
       object = typedArray;

--- a/modules/builder/src/writers/xviz-writer/xviz-writer.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-writer.js
@@ -67,7 +67,7 @@ export default class XVIZWriter {
 
     if (this.options.binary) {
       const options = {
-        flattenArrays: false
+        flattenArrays: true
       };
 
       writeBinaryXVIZtoFile(this.sink, xvizDirectory, '1-frame', xvizMetadata, options);
@@ -95,7 +95,7 @@ export default class XVIZWriter {
 
     if (this.options.binary) {
       const options = {
-        flattenArrays: false
+        flattenArrays: true
       };
 
       if (this.options.draco) {

--- a/modules/parser/src/parsers/filter-vertices.js
+++ b/modules/parser/src/parsers/filter-vertices.js
@@ -35,7 +35,7 @@ export function filterVertices(vertices) {
       newVertices[index++] = v[0];
       newVertices[index++] = v[1];
       newVertices[index++] = v[2];
-      lastEmittedVertex = new Vector3(v);
+      lastEmittedVertex = new Vector3(v[0], v[1], v[2]);
       lastEmittedIndex = i;
     }
   }

--- a/modules/parser/src/workers/stream-data-worker.js
+++ b/modules/parser/src/workers/stream-data-worker.js
@@ -29,6 +29,7 @@ export default config => self => {
         for (const streamName in message.streams) {
           const stream = message.streams[streamName];
           getTransferList(stream.pointCloud, true, transfers);
+          getTransferList(stream.vertices, false, transfers);
           if (stream.images && stream.images.length) {
             stream.images.forEach(image => getTransferList(image, true, transfers));
           }
@@ -46,8 +47,12 @@ export default config => self => {
     message = preSerialize(message);
 
     /* uncomment for debug */
+    // let size = 0;
+    // for (const item of transfers) {
+    //   size += item.byteLength;
+    // }
     // message._size = {
-    //   arraybuffer: transfers.size
+    //   arraybuffer: size
     // };
     // message._sentAt = Date.now();
 

--- a/test/modules/builder/xviz-loader/xviz-encode-parse.spec.js
+++ b/test/modules/builder/xviz-loader/xviz-encode-parse.spec.js
@@ -132,8 +132,7 @@ test('pack-unpack-pack-json', t => {
   const frameBinary = encodeBinaryXVIZ(frame, options);
   // TODO/ib - might be interesting to check why this has increased.
   // Should make effort to keep overhead small in loaders.gl
-  // t.equal(frameBinary.byteLength, 664);
-  t.equal(frameBinary.byteLength, 708);
+  t.equal(frameBinary.byteLength, 584);
 
   const xvizBinaryDecoded2 = parseBinaryXVIZ(frameBinary);
   const lidar = xvizBinaryDecoded2.state_updates[0].primitives.lidarPoints;

--- a/test/modules/parser/parsers/parse-xviz-stream.spec.js
+++ b/test/modules/parser/parsers/parse-xviz-stream.spec.js
@@ -306,10 +306,11 @@ tape('parseXVIZStream#primitive no-data entries', t => {
       features: [
         {
           type: 'polygon2d',
-          vertices: [[-10, 10, 0], [10, 10, 0], [10, -10, 0], [-10, -10, 0], [-10, 10, 0]]
+          vertices: new Float32Array([-10, 10, 0, 10, 10, 0, 10, -10, 0, -10, -10, 0, -10, 10, 0])
         }
       ],
       labels: [],
+      vertices: new Float32Array([-10, 10, 0, 10, 10, 0, 10, -10, 0, -10, -10, 0, -10, 10, 0]),
       pointCloud: null,
       images: [],
       components: [],
@@ -319,6 +320,7 @@ tape('parseXVIZStream#primitive no-data entries', t => {
       lookAheads: [],
       features: [],
       labels: [],
+      vertices: null,
       pointCloud: null,
       images: [],
       components: [],


### PR DESCRIPTION
Binary saves up to 80% size-wise comparing to JSON. Plus additional deserialization time.
In the KITTI dataset the difference is not visible since it only has ~2KB polygon/polyline data.