### PR TITLE
XVIZ GLB data encoded with AVS_xviz extension

### DIFF
--- a/modules/builder/package.json
+++ b/modules/builder/package.json
@@ -14,9 +14,9 @@
     "dist"
   ],
   "dependencies": {
-    "@loaders.gl/draco": "^1.0.3",
-    "@loaders.gl/gltf": "^1.0.3",
-    "@loaders.gl/polyfills": "^1.0.3",
+    "@loaders.gl/draco": "^1.1.0-alpha.1",
+    "@loaders.gl/gltf": "^1.1.0-alpha.1",
+    "@loaders.gl/polyfills": "^1.1.0-alpha.1",
     "@turf/turf": "^5.1.6",
     "base64-js": "^1.3.0",
     "math.gl": "^2.3.1",

--- a/modules/builder/package.json
+++ b/modules/builder/package.json
@@ -14,9 +14,9 @@
     "dist"
   ],
   "dependencies": {
-    "@loaders.gl/draco": "^1.1.0-alpha.1",
-    "@loaders.gl/gltf": "^1.1.0-alpha.1",
-    "@loaders.gl/polyfills": "^1.1.0-alpha.1",
+    "@loaders.gl/draco": "^1.1.0",
+    "@loaders.gl/gltf": "^1.1.0",
+    "@loaders.gl/polyfills": "^1.1.0",
     "@turf/turf": "^5.1.6",
     "base64-js": "^1.3.0",
     "math.gl": "^2.3.1",

--- a/modules/builder/src/writers/xviz-writer/xviz-binary-writer.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-binary-writer.js
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: remove this code, it duplicates io/src/writers/xviz-binary-writer.js
+
+export const XVIZ_GLTF_EXTENSION = 'AVS_xviz'; // copied from @xviz/parser
+
 import '@loaders.gl/polyfills';
 import {GLTFBuilder} from '@loaders.gl/gltf';
 import {packBinaryJson} from './xviz-pack-binary';
@@ -23,7 +27,12 @@ export function encodeBinaryXVIZ(xvizJson, options) {
   const packedData = packBinaryJson(xvizJson, gltfBuilder, null, options);
 
   // As permitted by glTF, we put all XVIZ data in a top-level subfield.
-  gltfBuilder.addApplicationData('xviz', packedData, {nopack: true});
+  const {useAVSXVIZExtension} = options;
+  if (useAVSXVIZExtension === true) {
+    gltfBuilder.addExtension(XVIZ_GLTF_EXTENSION, packedData, {nopack: true});
+  } else {
+    gltfBuilder.addApplicationData('xviz', packedData, {nopack: true});
+  }
 
   return gltfBuilder.encodeAsGLB(options);
 }

--- a/modules/cli/src/websocket.js
+++ b/modules/cli/src/websocket.js
@@ -75,6 +75,10 @@ export class WebSocketInterface {
         // Convert from binary to JSON object
         const parsed = parseBinaryXVIZ(message.data);
         this.processMessage(parsed);
+      } else {
+        const utf8decoder = new TextDecoder();
+        const parsed = JSON.parse(utf8decoder.decode(message.data));
+        this.processMessage(parsed);
       }
     } else {
       const parsed = JSON.parse(message.data);

--- a/modules/io/package.json
+++ b/modules/io/package.json
@@ -15,8 +15,8 @@
     "node.js"
   ],
   "dependencies": {
-    "@loaders.gl/draco": "^1.1.0-alpha.1",
-    "@loaders.gl/gltf": "^1.1.0-alpha.1",
+    "@loaders.gl/draco": "^1.1.0",
+    "@loaders.gl/gltf": "^1.1.0",
     "@turf/turf": "^5.1.6",
     "base64-js": "^1.3.0",
     "math.gl": "^2.0.0",

--- a/modules/io/package.json
+++ b/modules/io/package.json
@@ -15,8 +15,8 @@
     "node.js"
   ],
   "dependencies": {
-    "@loaders.gl/draco": "^0.7.1",
-    "@loaders.gl/gltf": "^0.7.2",
+    "@loaders.gl/draco": "^1.1.0-alpha.1",
+    "@loaders.gl/gltf": "^1.1.0-alpha.1",
     "@turf/turf": "^5.1.6",
     "base64-js": "^1.3.0",
     "math.gl": "^2.0.0",

--- a/modules/io/src/writers/xviz-binary-writer.js
+++ b/modules/io/src/writers/xviz-binary-writer.js
@@ -51,8 +51,8 @@ export function encodeBinaryXVIZ(xvizJson, options) {
   const packedData = packBinaryJson(xvizJson, gltfBuilder, null, options);
 
   // As permitted by glTF, we put all XVIZ data in a top-level subfield.
-  const {compatible} = options;
-  if (compatible === true) {
+  const {useAVSXVIZExtension} = options;
+  if (useAVSXVIZExtension === true) {
     gltfBuilder.addExtension(XVIZ_GLTF_EXTENSION, packedData, {nopack: true});
   } else {
     gltfBuilder.addApplicationData('xviz', packedData, {nopack: true});

--- a/modules/parser/package.json
+++ b/modules/parser/package.json
@@ -17,8 +17,8 @@
     "text-encoding": false
   },
   "dependencies": {
-    "@loaders.gl/draco": "^1.0.3",
-    "@loaders.gl/gltf": "^1.0.3",
+    "@loaders.gl/draco": "^1.1.0-alpha.1",
+    "@loaders.gl/gltf": "^1.1.0-alpha.1",
     "base64-js": "^1.3.0",
     "color": "^3.0.0",
     "math.gl": "^2.3.1",

--- a/modules/parser/package.json
+++ b/modules/parser/package.json
@@ -17,8 +17,8 @@
     "text-encoding": false
   },
   "dependencies": {
-    "@loaders.gl/draco": "^1.1.0-alpha.1",
-    "@loaders.gl/gltf": "^1.1.0-alpha.1",
+    "@loaders.gl/draco": "^1.1.0",
+    "@loaders.gl/gltf": "^1.1.0",
     "base64-js": "^1.3.0",
     "color": "^3.0.0",
     "math.gl": "^2.3.1",

--- a/modules/parser/src/constants.js
+++ b/modules/parser/src/constants.js
@@ -30,3 +30,5 @@ export const STATE_UPDATE_TYPE = {
   // Deprecated
   snapshot: 'INCREMENTAL'
 };
+
+export const XVIZ_GLTF_EXTENSION = 'AVS_xviz';

--- a/modules/parser/src/index.js
+++ b/modules/parser/src/index.js
@@ -67,3 +67,4 @@ export {
 } from './parsers/parse-xviz-message-sync';
 export {parseVideoMessageV1 as parseStreamVideoMessage} from './parsers/parse-video-message-v1';
 export {XVIZ_MESSAGE_TYPE as LOG_STREAM_MESSAGE} from './constants';
+export {XVIZ_GLTF_EXTENSION} from './constants';

--- a/modules/parser/src/loaders/xviz-loader/xviz-binary-loader.js
+++ b/modules/parser/src/loaders/xviz-loader/xviz-binary-loader.js
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-/* eslint-disable */
+
 import {GLTFParser} from '@loaders.gl/gltf';
 
 import {XVIZ_GLTF_EXTENSION} from '../../constants';
@@ -29,10 +29,9 @@ export function parseBinaryXVIZ(arrayBuffer) {
 
   // TODO/ib - Fix when loaders.gl API is fixed
   let xviz = gltfParser.getApplicationData('xviz');
-  console.log(`FOO: ${xviz}`);
+
   if (xviz === undefined) {
     xviz = gltfParser.getExtension(XVIZ_GLTF_EXTENSION);
-    console.log(`BAR: ${xviz}`);
   }
 
   return xviz;

--- a/modules/parser/src/loaders/xviz-loader/xviz-binary-loader.js
+++ b/modules/parser/src/loaders/xviz-loader/xviz-binary-loader.js
@@ -11,8 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+/* eslint-disable */
 import {GLTFParser} from '@loaders.gl/gltf';
+
+import {XVIZ_GLTF_EXTENSION} from '../../constants';
 
 const MAGIC_XVIZ = 0x5856495a; // XVIZ in Big-Endian ASCII
 const MAGIC_GLTF = 0x676c5446; // glTF in Big-Endian ASCII
@@ -26,7 +28,14 @@ export function parseBinaryXVIZ(arrayBuffer) {
   gltfParser.parse(arrayBuffer, {createImages: false});
 
   // TODO/ib - Fix when loaders.gl API is fixed
-  return gltfParser.getApplicationData('xviz');
+  let xviz = gltfParser.getApplicationData('xviz');
+  console.log(`FOO: ${xviz}`);
+  if (xviz === undefined) {
+    xviz = gltfParser.getExtension(XVIZ_GLTF_EXTENSION);
+    console.log(`BAR: ${xviz}`);
+  }
+
+  return xviz;
 }
 
 export function isBinaryXVIZ(arrayBuffer) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,10 +655,17 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.3.1":
+"@babel/runtime@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
   integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.3.1":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -695,69 +702,51 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@loaders.gl/core@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-1.0.3.tgz#60a1467e583f28d974a72f947cf2c7c2bc266393"
-  integrity sha512-ENyW3UqPgtOx81iY23Y8jD7FJ6miNduOzV6Z1xY7pXwoOGrF2BXTJ3P7KPLXTIBN98mh67jUax0fouBhrQL2Kw==
+"@loaders.gl/core@1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-1.1.0-alpha.1.tgz#1f8f86163e07417f2c3b522f4e2119c9b3419b58"
+  integrity sha512-kFk6u6nUi+itDKc+76Ei+t1ujRuqVb+GjtjXhmOL+XomYEf4rXtMOsteIJ19hr02fq27VlwdNw6jrukwr39O1A==
   dependencies:
     "@babel/runtime" "^7.3.1"
 
-"@loaders.gl/core@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/core/-/core-0.7.1.tgz#fd122d5518864d2ed2d851fd2a21a04d2613abe7"
-  integrity sha512-xdcevhaDcp8dEtvHXdD1JhxojAZVQj2mMvDgAAGS8rV7gD7/jOVVdp0nyilKbcXJxN/tIABBrYivTOkqoTMzPQ==
+"@loaders.gl/draco@^1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-1.1.0-alpha.1.tgz#91b63eaa38f9b326011ff887b03df38c78c6c5e7"
+  integrity sha512-tW37o0qG3LbzGIrBRtGzG7Jsy+scim/Q+b0l6/bo6FEl8JRmIFni0ydyGq+IZV+rWbMVUiNYvELdkjgVYcSMbQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    text-encoding "^0.6.4"
-
-"@loaders.gl/draco@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-0.7.1.tgz#92ddb8d2d7371883e0099d6f45cbc6a3a7893c66"
-  integrity sha512-bISQD9+EaRwJdqgMDT1CrTT05OrwE7ZqKstotnpISWkQiiq0DbLi0lXwa1VQRHU4dXMtQoItkR4PyJTw7DDM+g==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@loaders.gl/core" "^0.7.1"
+    "@loaders.gl/loader-utils" "1.1.0-alpha.1"
     draco3d "^1.3.4"
 
-"@loaders.gl/draco@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/draco/-/draco-1.0.3.tgz#f2be4f4aa61fc68d3422f90df7eab7ead107c248"
-  integrity sha512-CKKKtqnJAuLSebSsmNDeOL5FlxPuiqwheNrfD6DQxh1+PRweO8VxNqgS3oke8UNfSC7yCUnE4O3kn5q8YhfdEA==
+"@loaders.gl/gltf@^1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-1.1.0-alpha.1.tgz#48b17f214a608bea7ed6baf0559c16fa3e2c716b"
+  integrity sha512-88sekB81DPIulVWTQ36045nCiAtT0sfhVr9+fYiGYaYNNA8go+T/ZAK+tgwpbKQQ86bdMZHKY1lt/teRXnj2iA==
+  dependencies:
+    "@loaders.gl/core" "1.1.0-alpha.1"
+    "@loaders.gl/images" "1.1.0-alpha.1"
+
+"@loaders.gl/images@1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.1.0-alpha.1.tgz#4fc344583b6c4510688719c45ec5b9a72d710479"
+  integrity sha512-HsI0ju68uQ88qq0ULR7YytGuH9DFOULjnBPMu9tAkwjrd5oNR+SaHPtq2tENBl6IdzeFidl8AaROW87T2kYDLQ==
+
+"@loaders.gl/loader-utils@1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/loader-utils/-/loader-utils-1.1.0-alpha.1.tgz#09d93ed4957ea43182b112b115adc2216aacdd89"
+  integrity sha512-zKOZoOXOCZ3IjyGSabmhEhYaaSDohu5jZ7Bwzajqbc1nc2bDciVP6a65Qvk79vjMgg8v02gYdy/xIESXeXfnVQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    "@loaders.gl/core" "1.0.3"
-    draco3d "^1.3.4"
 
-"@loaders.gl/gltf@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-0.7.2.tgz#ace809c91efe1a47ff8f34c4305a8dff478e2053"
-  integrity sha512-Mzx3GqEQ4mTPIrn3vLkynFzTOLToE9aYPrKMcxmkqQ7UsvpGrUNSZK1ToOTQhOmQ72M33tN4mSxqlpePw/KkdQ==
+"@loaders.gl/polyfills@^1.1.0-alpha.1":
+  version "1.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-1.1.0-alpha.1.tgz#779e8fbeb54b954457d3fa9d35e46574e0eb3d55"
+  integrity sha512-aNd1IcQ8oSnQUv6QJaSpF2hnDu2tV7o0S91MQClzlRuIL5qi0EoRfak3R/zwKRqGsW4+I9ZDe/EcwgQgW3f4FQ==
   dependencies:
-    "@loaders.gl/core" "^0.7.1"
-
-"@loaders.gl/gltf@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/gltf/-/gltf-1.0.3.tgz#dedc5f8a5db22f8bf6e991037cd561951126c934"
-  integrity sha512-sqS41Ldeza/ZS0RASXLHDLm9D6/8u5Y8o8jwxiIYvM6AUg9wtnhZv4Pp5KtrPY0t1cxeJcr6pnBWJwFDd5lxFQ==
-  dependencies:
-    "@loaders.gl/core" "1.0.3"
-    "@loaders.gl/images" "1.0.3"
-
-"@loaders.gl/images@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/images/-/images-1.0.3.tgz#f2d4d75f53a84289b30900c44711ab4fd32e25bd"
-  integrity sha512-S3UV2/apkWkf+ULT/nt8+SYFh7WYir/mCL5VK/dYUnOgNs+0JLyG+0i35bMWg/GsHN683Z9Ja1m9zRsIz/EOdA==
-  dependencies:
-    canvas-to-blob "0.0.0"
     get-pixels "^3.3.2"
     ndarray "^1.0.18"
     save-pixels "^2.3.2"
     through "^2.3.8"
-
-"@loaders.gl/polyfills@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@loaders.gl/polyfills/-/polyfills-1.0.3.tgz#3dac9b7bfb742f292d212d526e28fbdec0854b9c"
-  integrity sha512-FLKkflNa6lolK3W6JY19hFcgbqW3zFXUZgESyQ5ACsg7eLWuBZtcFYKafBgWcWVL77sWp0t1xsrNKtvKLrRYtg==
 
 "@probe.gl/bench@^3.0.1":
   version "3.0.1"
@@ -2918,11 +2907,6 @@ caniuse-lite@^1.0.30000963:
   version "1.0.30000963"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz#5be481d5292f22aff5ee0db4a6c049b65b5798b1"
   integrity sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==
-
-canvas-to-blob@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/canvas-to-blob/-/canvas-to-blob-0.0.0.tgz#f1db4dd083ddc74a78fe5bce6a869786b59f51f3"
-  integrity sha1-8dtN0IPdx0p4/lvOaoaXhrWfUfM=
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
The current XVIZ GLB based format adds a root `xviz` property to the
JSON GLB chunk.  This violates the GLTF spec and can make parsing XVIZ
data in standard parser difficult.  By using the extensions mechanism
of the spec we keep compatibility with very little code changes.

Essentially this:

```
{
   "xviz": {...}
}
```

Becomes this:

```
{
   "extensions": {
       "AVS_xviz": {...}
    },
    "extensionsUsed": ["AVS_xviz"]
}
```

For now simply support parsing both formats to allow be compatible
with XVIZ GLB generators using standard GLTF libraries.