### PR TITLE
Correction and cleanup for Quick Start

### DIFF
--- a/modules/io/package.json
+++ b/modules/io/package.json
@@ -17,19 +17,13 @@
   "dependencies": {
     "@loaders.gl/draco": "^1.1.0",
     "@loaders.gl/gltf": "^1.1.0",
+    "@loaders.gl/polyfills": "^1.1.0",
     "@turf/turf": "^5.1.6",
     "base64-js": "^1.3.0",
     "math.gl": "^2.0.0",
     "text-encoding": "^0.6.4"
   },
-  "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "cover": "NODE_ENV=test BABEL_ENV=cover npx nyc node ../../test/start.js cover"
-  },
+  "scripts": {},
   "browser": {
     "./src/io/fs-sink.js": false,
     "./src/io/fs-source.js": false

--- a/modules/io/src/writers/xviz-binary-writer.js
+++ b/modules/io/src/writers/xviz-binary-writer.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import '@loaders.gl/polyfills';
 import {XVIZBaseWriter} from './xviz-base-writer';
 import {GLTFBuilder} from '@loaders.gl/gltf';
 import {DracoWriter, DracoLoader} from '@loaders.gl/draco';

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -26,14 +26,7 @@
     "ws": "^6.2.0",
     "yargs": "^12.0.5"
   },
-  "scripts": {
-    "clean": "rm -fr dist && mkdir -p dist",
-    "build-es6": "BABEL_ENV=es6 babel src --config-file ../../babel.config.js --out-dir dist/es6 --source-maps --ignore 'node_modules/'",
-    "build-esm": "BABEL_ENV=esm babel src --config-file ../../babel.config.js --out-dir dist/esm --source-maps --ignore 'node_modules/'",
-    "build-es5": "BABEL_ENV=es5 babel src --config-file ../../babel.config.js --out-dir dist/es5 --source-maps --ignore 'node_modules/'",
-    "build": "npm run clean && npm run build-es6 && npm run build-esm && npm run build-es5",
-    "cover": "NODE_ENV=test BABEL_ENV=cover npx nyc node ../../test/start.js cover"
-  },
+  "scripts": {},
   "engines": {
     "node": ">= 8"
   }

--- a/scripts/run-kitti-example.sh
+++ b/scripts/run-kitti-example.sh
@@ -62,7 +62,7 @@ OUTPUT_DIR="${SCRIPT_DIR}/../data/generated/kitti/2011_09_26/2011_09_26_drive_00
 if [ "$force_xviz_conversion" = "true" ] || ([ ! -f "${OUTPUT_DIR}/1-frame.json" ] && [ ! -f "${OUTPUT_DIR}/1-frame.glb" ]) ; then
     echo "Generating default KITTI XVIZ data"
     mkdir -p "${OUTPUT_DIR}"
-    (cd "${SCRIPT_DIR}/../examples/converters/kitti" && yarn start -d ${INPUT_DIR} -o "${OUTPUT_DIR}")
+    (cd "${SCRIPT_DIR}/../examples/converters/kitti" && yarn && yarn start -d ${INPUT_DIR} -o "${OUTPUT_DIR}")
 fi
 
 # Start server & web app


### PR DESCRIPTION
- clean up new module 'scripts' as ocular-dev-tools handles this now
- make sure the run-kitti-example ensure dependencies are installed
- add polyfill import for @loaders.gl