### PR TITLE
Improve enum coversion for protobuf checks

### DIFF
--- a/modules/schema/src/index.js
+++ b/modules/schema/src/index.js
@@ -20,6 +20,6 @@ export {XVIZSessionValidator, MessageTypes} from './session-validator';
 
 export {loadProtos, getXVIZProtoTypes, EXTENSION_PROPERTY} from './proto-validation';
 
-export {protoEnumsToInts, enumToIntField} from './proto-utils';
+export {getProtoEnumTypes, protoEnumsToInts, enumToIntField} from './proto-utils';
 
 export {StructEncode} from './proto-struct-wrapper';


### PR DESCRIPTION
protobuf.js does not handle JSON string to enum conversio so we do
this ourselves.  We now properly handle package scope enums and name
lookups.  This lets us handle more complicated XVIZ protobuf files.