### PR TITLE
Fix json formatting of an Array with TypedArray elements

### DIFF
--- a/modules/builder/src/writers/xviz-writer/xviz-json-encoder.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-json-encoder.js
@@ -18,16 +18,16 @@ import base64js from 'base64-js';
 // - primitives with typed array fields are turned into arrays
 // - primtives of type image have the data turned into a base64 string
 /* eslint-disable complexity */
-export function xvizConvertJson(object, keyName) {
+export function xvizConvertJson(object, keyName, nestedDepth = 0) {
   if (Array.isArray(object)) {
-    return object.map(element => xvizConvertJson(element, keyName));
+    return object.map(element => xvizConvertJson(element, keyName, nestedDepth + 1));
   }
 
   // Typed arrays become normal arrays
   // TODO: no way to know if this should be 3 or 4
   if (ArrayBuffer.isView(object)) {
     // Return normal arrays
-    if (!(keyName === 'vertices' || keyName === 'points')) {
+    if (!(keyName === 'vertices' || keyName === 'points') || nestedDepth > 0) {
       return Array.from(object);
     }
 
@@ -60,7 +60,7 @@ export function xvizConvertJson(object, keyName) {
     // Handle all other objects
     const newObject = {};
     for (const key in object) {
-      newObject[key] = xvizConvertJson(object[key], key, keyName);
+      newObject[key] = xvizConvertJson(object[key], key);
     }
     return newObject;
   }

--- a/modules/io/src/writers/xviz-json-encoder.js
+++ b/modules/io/src/writers/xviz-json-encoder.js
@@ -18,16 +18,16 @@ import base64js from 'base64-js';
 // - primitives with typed array fields are turned into arrays
 // - primtives of type image have the data turned into a base64 string
 /* eslint-disable complexity */
-export function xvizConvertJson(object, keyName) {
+export function xvizConvertJson(object, keyName, nestedDepth = 0) {
   if (Array.isArray(object)) {
-    return object.map(element => xvizConvertJson(element, keyName));
+    return object.map(element => xvizConvertJson(element, keyName, nestedDepth + 1));
   }
 
   // Typed arrays become normal arrays
   // TODO: no way to know if this should be 3 or 4
   if (ArrayBuffer.isView(object)) {
     // Return normal arrays
-    if (!(keyName === 'vertices' || keyName === 'points')) {
+    if (!(keyName === 'vertices' || keyName === 'points') || nestedDepth > 0) {
       return Array.from(object);
     }
 
@@ -60,7 +60,7 @@ export function xvizConvertJson(object, keyName) {
     // Handle all other objects
     const newObject = {};
     for (const key in object) {
-      newObject[key] = xvizConvertJson(object[key], key, keyName);
+      newObject[key] = xvizConvertJson(object[key], key);
     }
     return newObject;
   }

--- a/test/modules/builder/writers/xviz-writer-points.spec.js
+++ b/test/modules/builder/writers/xviz-writer-points.spec.js
@@ -74,7 +74,7 @@ function makeFrame(points, colors) {
   };
 }
 
-test('XVIZBuilder#points', t => {
+test('XVIZBuilder#points binary', t => {
   const points_flat = [0, 0, 0, 4, 0, 0, 4, 3, 0];
   const colors_flat = [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255];
 
@@ -84,11 +84,23 @@ test('XVIZBuilder#points', t => {
   const points_typed = Float32Array.from([0, 0, 0, 4, 0, 0, 4, 3, 0]);
   const colors_typed = Uint8Array.from([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255]);
 
+  const points_typed_nested = [
+    Float32Array.from([0, 0, 0]),
+    Float32Array.from([4, 0, 0]),
+    Float32Array.from([4, 3, 0])
+  ];
+  const colors_typed_nested = [
+    Uint8Array.from([255, 0, 0, 255]),
+    Uint8Array.from([0, 255, 0, 255]),
+    Uint8Array.from([0, 0, 255, 255])
+  ];
+
   // Generate a frame with specific points and colors
   [
     makeFrame(points_flat, colors_flat),
     makeFrame(points_nested, colors_nested),
-    makeFrame(points_typed, colors_typed)
+    makeFrame(points_typed, colors_typed),
+    makeFrame(points_typed_nested, colors_typed_nested)
   ].forEach(frame => {
     // Test that each "points" field is properly replaced.
     const sink = new MemorySink();
@@ -103,6 +115,63 @@ test('XVIZBuilder#points', t => {
     const data = sink.get('test', '2-frame.glb');
     t.ok(data.toString().includes('#/accessors/0'), 'data has accessor 0');
     t.ok(data.toString().includes('#/accessors/1'), 'data has accessor 1');
+  });
+  t.end();
+});
+
+test('XVIZBuilder#points json', t => {
+  const points_flat = [0, 0, 0, 4, 0, 0, 4, 3, 0];
+  const colors_flat = [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255];
+
+  const points_nested = [[0, 0, 0], [4, 0, 0], [4, 3, 0]];
+  const colors_nested = [[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255]];
+
+  const points_typed = Float32Array.from([0, 0, 0, 4, 0, 0, 4, 3, 0]);
+  const colors_typed = Uint8Array.from([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255]);
+
+  const points_typed_nested = [
+    Float32Array.from([0, 0, 0]),
+    Float32Array.from([4, 0, 0]),
+    Float32Array.from([4, 3, 0])
+  ];
+  const colors_typed_nested = Uint8Array.from([10, 10, 10, 255, 20, 20, 20, 255, 30, 30, 30, 255]);
+  // TODO(twojtasz): Should be this, but We don't know how to handle this case as colors could have 3 or 4 elements
+  /*
+  const colors_typed_nested = [
+    Uint8Array.from([255, 0, 0, 255]),
+    Uint8Array.from([0, 255, 0, 255]),
+    Uint8Array.from([0, 0, 255, 255])
+  ];
+  */
+
+  // Generate a frame with specific points and colors
+  [
+    makeFrame(points_flat, colors_flat),
+    makeFrame(points_nested, colors_nested),
+    makeFrame(points_typed, colors_typed),
+    makeFrame(points_typed_nested, colors_typed_nested)
+  ].forEach(frame => {
+    // Test that each "points" field is properly replaced.
+    const sink = new MemorySink();
+    const writer = new XVIZWriter({dataSink: sink, envelope: true, binary: false, json: true});
+
+    writer.writeFrame('test', 0, frame);
+
+    t.ok(sink.has('test', '2-frame.json'), 'wrote json frame');
+
+    // TODO: once this is merged into @xviz/io replace this with actual
+    // parsing and validation of the structure.
+    const data = sink.get('test', '2-frame.json');
+    const msg = JSON.parse(data);
+    const points = msg.data.updates[0].primitives['/test/points'].points[0].points;
+    if (points.length === 9) {
+      t.ok(Number.isFinite(points[0]), 'Flat array has Number @ index 0');
+    } else if (points.length === 3) {
+      t.ok(Array.isArray(points[0]), 'Nested array has Array @ index 0');
+      t.equals(points[0].length, 3, 'Nested array @ index 0 has 3');
+    } else {
+      t.fail('Points has an unexpected number of entries');
+    }
   });
   t.end();
 });

--- a/test/modules/io/writers/xviz-writer-points.spec.js
+++ b/test/modules/io/writers/xviz-writer-points.spec.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 /* eslint-disable camelcase */
 import test from 'tape-catch';
-import {XVIZBinaryWriter, MemorySourceSink} from '@xviz/io';
+import {XVIZBinaryWriter, XVIZJSONWriter, XVIZData, MemorySourceSink} from '@xviz/io';
 
 const PRIMARY_POSE_STREAM = '/vehicle_pose';
 const DEFAULT_POSE = {
@@ -61,11 +61,23 @@ test('XVIZBinaryWriter#points not made binary because too few elements', t => {
   const points_typed = Float32Array.from([0, 0, 0, 4, 0, 0, 4, 3, 0]);
   const colors_typed = Uint8Array.from([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255]);
 
+  const points_typed_nested = [
+    Float32Array.from([1, 1, 1]),
+    Float32Array.from([2, 2, 2]),
+    Float32Array.from([3, 3, 3])
+  ];
+  const colors_typed_nested = [
+    Uint8Array.from([10, 10, 10, 255]),
+    Uint8Array.from([20, 20, 20, 255]),
+    Uint8Array.from([30, 30, 30, 255])
+  ];
+
   // Generate a frame with specific points and colors
   [
     makeFrame(points_flat, colors_flat),
     makeFrame(points_nested, colors_nested),
-    makeFrame(points_typed, colors_typed)
+    makeFrame(points_typed, colors_typed),
+    makeFrame(points_typed_nested, colors_typed_nested)
   ].forEach(frame => {
     // Test that each "points" field is properly replaced.
     const sink = new MemorySourceSink();
@@ -80,6 +92,83 @@ test('XVIZBinaryWriter#points not made binary because too few elements', t => {
     const data = sink.readSync('2-frame.glb');
     t.ok(data.toString().includes('#/accessors/0'), 'data has accessor 0');
     t.ok(data.toString().includes('#/accessors/1'), 'data has accessor 1');
+  });
+  t.end();
+});
+
+test('XVIZJSONWriter#points', t => {
+  const points_flat = [1, 1, 1, 2, 2, 2, 3, 3, 3];
+  const colors_flat = [10, 10, 10, 20, 20, 20, 30, 30, 30];
+
+  const points_nested = [[1, 1, 1], [2, 2, 2], [3, 3, 3]];
+  const colors_nested = [[10, 10, 10, 255], [20, 20, 20, 255], [30, 30, 30, 255]];
+
+  const points_typed = Float32Array.from([1, 1, 1, 2, 2, 2, 3, 3, 3]);
+  const colors_typed = Uint8Array.from([10, 10, 10, 255, 20, 20, 20, 255, 30, 30, 30, 255]);
+
+  const points_typed_nested = [
+    Float32Array.from([1, 1, 1]),
+    Float32Array.from([2, 2, 2]),
+    Float32Array.from([3, 3, 3])
+  ];
+
+  const colors_typed_nested = Uint8Array.from([10, 10, 10, 255, 20, 20, 20, 255, 30, 30, 30, 255]);
+  // TODO(twojtasz): Should be this, but We don't know how to handle this case as colors could have 3 or 4 elements
+  /*
+  const colors_typed_nested = [
+    Uint8Array.from([10, 10, 10, 255]),
+    Uint8Array.from([20, 20, 20, 255]),
+    Uint8Array.from([30, 30, 30, 255])
+  ];
+  */
+
+  // Generate a frame with specific points and colors
+  [
+    makeFrame(points_flat, colors_flat),
+    makeFrame(points_nested, colors_nested),
+    makeFrame(points_typed, colors_typed),
+    makeFrame(points_typed_nested, colors_typed_nested)
+  ].forEach(frame => {
+    // Test that each "points" field is properly replaced.
+    const sink = new MemorySourceSink();
+    const writer = new XVIZJSONWriter(sink);
+
+    writer.writeMessage(0, frame);
+
+    t.ok(sink.has('2-frame.json'), 'wrote json frame');
+
+    const data = sink.readSync('2-frame.json');
+    const msg = new XVIZData(data).message();
+    const writtenPoints = msg.data.updates[0].primitives['/test/points'].points[0];
+
+    t.ok(writtenPoints.points, 'Has points');
+    t.ok(writtenPoints.colors, 'Has colors');
+
+    if (writtenPoints.points.length === 9) {
+      t.equals(writtenPoints.points[0], 1, 'point 1 matches input data');
+      t.equals(writtenPoints.points[3], 2, 'point 2 matches input data');
+      t.equals(writtenPoints.points[6], 3, 'point 3  matches input data');
+
+      t.equals(writtenPoints.colors[0], 10, 'color 1 matches input data');
+      t.equals(writtenPoints.colors[4], 20, 'color 2 matches input data');
+      t.equals(writtenPoints.colors[8], 30, 'color 3 matches input data');
+    } else if (writtenPoints.points.length === 3) {
+      t.ok(Array.isArray(writtenPoints.points[0]), 'Nested array has Array @ index 0');
+      t.equals(writtenPoints.points[0].length, 3, 'Nested array @ index 0 has 3');
+
+      t.equals(writtenPoints.points[0][0], 1, 'Nested point 1 matches input data');
+      t.equals(writtenPoints.points[1][0], 2, 'Nested point 2 matches input data');
+      t.equals(writtenPoints.points[2][0], 3, 'Nested point 3  matches input data');
+
+      // TODO(twojtasz): We don't know how to handle this see above
+      /* 
+      t.equals(writtenPoints.colors[0][0], 10, 'Nested color 1 matches input data');
+      t.equals(writtenPoints.colors[1][0], 20, 'Nested color 2 matches input data');
+      t.equals(writtenPoints.colors[2][0], 30, 'Nested color 3 matches input data');
+      */
+    } else {
+      t.fail('Points has an unexpected number of entries');
+    }
   });
   t.end();
 });


### PR DESCRIPTION
The KITTI conversion creates point clouds as an Array of TypedArrays.
This was not working when formatted as json because the conversion only
hands the property name and made assumptions about the typed arrays
being the top-level.

As a result it was creating an addition array nesting that broke when
it encounted an Array of TypedArrays.

The fix tracks the array nesting and if encounters a nested array,
returns an array from the TypedArray w/o additional nesting

Fixed in both @xviz/builder & @xviz/io