### PR TITLE
Add protobuf support to KITTI example

### DIFF
--- a/examples/converters/kitti/src/args.js
+++ b/examples/converters/kitti/src/args.js
@@ -31,7 +31,12 @@ parser.addArgument(['-o', '--output'], {
 
 parser.addArgument('--json', {
   action: 'storeTrue',
-  help: 'Generate JSON XVIZ output instead of the binary file format'
+  help: 'Generate JSON XVIZ output instead of the GLB file format'
+});
+
+parser.addArgument('--protobuf', {
+  action: 'storeTrue',
+  help: 'Generate Protobuf XVIZ output instead of the GLB file file format'
 });
 
 parser.addArgument(['--disable-streams'], {
@@ -75,6 +80,7 @@ module.exports = function getArgs() {
     imageMaxWidth: Number(args.image_max_width),
     imageMaxHeight: Number(args.image_max_height),
     messageLimit: Number(args.message_limit),
-    writeJson: Number(args.json)
+    writeJson: Number(args.json),
+    writeProtobuf: Number(args.protobuf)
   };
 };

--- a/examples/converters/kitti/src/transform.js
+++ b/examples/converters/kitti/src/transform.js
@@ -14,7 +14,7 @@
 
 /* eslint-disable camelcase */
 import {FileSink} from '@xviz/io/node';
-import {XVIZJSONWriter, XVIZBinaryWriter} from '@xviz/io';
+import {XVIZBinaryWriter, XVIZJSONWriter, XVIZProtobufWriter} from '@xviz/io';
 
 import {KittiConverter} from './converters';
 
@@ -30,7 +30,8 @@ module.exports = async function main(args) {
     cameraSources,
     imageMaxWidth,
     imageMaxHeight,
-    writeJson
+    writeJson,
+    writeProtobuf
   } = args;
 
   // This object orchestrates any data dependencies between the data sources
@@ -50,7 +51,14 @@ module.exports = async function main(args) {
 
   // This abstracts the details of the filenames expected by our server
   const sink = new FileSink(outputDir);
-  const xvizWriter = writeJson ? new XVIZJSONWriter(sink) : new XVIZBinaryWriter(sink);
+  let xvizWriter = null;
+  if (writeJson) {
+    xvizWriter = new XVIZJSONWriter(sink);
+  } else if (writeProtobuf) {
+    xvizWriter = new XVIZProtobufWriter(sink);
+  } else {
+    xvizWriter = new XVIZBinaryWriter(sink);
+  }
 
   // Write metadata file
   const xvizMetadata = converter.getMetadata();


### PR DESCRIPTION
Add the option `--protobuf` which will output the `#-frame.pbe` formatted XVIZ Messages.