### PR TITLE
Add protobuf support to @xviz/io

### DIFF
--- a/modules/io/package.json
+++ b/modules/io/package.json
@@ -20,6 +20,7 @@
     "@turf/turf": "^5.1.6",
     "base64-js": "^1.3.0",
     "math.gl": "^2.0.0",
+    "protobufjs": "^6.8.8",
     "text-encoding": "^0.6.4"
   },
   "scripts": {},

--- a/modules/io/src/common/protobuf-support.js
+++ b/modules/io/src/common/protobuf-support.js
@@ -1,0 +1,26 @@
+import {loadProtos} from '@xviz/schema';
+
+// All XVIZ messages
+export const XVIZ_PROTOBUF_MESSAGE_NAME = {
+  ENVELOPE: 'xviz.v2.Envelope',
+  START: 'xviz.v2.Start',
+  TRANSFORM_LOG: 'xviz.v2.TransformLog',
+  TRANSFORM_LOG_POINT_IN_TIME: 'xviz.v2.TransformPointInTime',
+  TRANSFORM_LOG_DONE: 'xviz.v2.TransformLogDone',
+  STATE_UPDATE: 'xviz.v2.StateUpdate',
+  RECONFIGURE: 'xviz.v2.Reconfigure',
+  METADATA: 'xviz.v2.Metadata',
+  ERROR: 'xviz.v2.Error'
+};
+
+// PBE1
+export const MAGIC_PBE1 = 0x50424531;
+export const XVIZ_PROTOBUF_MAGIC = Uint8Array.from([0x50, 0x42, 0x45, 0x31]);
+
+export const XVIZ_PROTOBUF_ROOT = loadProtos();
+
+export const XVIZ_PROTOBUF_MESSAGE = {
+  Envelope: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_MESSAGE_NAME.ENVELOPE),
+  Metadata: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_MESSAGE_NAME.METADATA),
+  StateUpdate: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_MESSAGE_NAME.STATE_UPDATE)
+};

--- a/modules/io/src/common/xviz-data.js
+++ b/modules/io/src/common/xviz-data.js
@@ -18,6 +18,7 @@ import {
   parseBinaryXVIZ,
   isGLBXVIZ,
   isJSONString,
+  isPBEXVIZ,
   getXVIZMessageType
 } from './loaders';
 import {XVIZMessage} from './xviz-message';
@@ -100,6 +101,12 @@ export class XVIZData {
         }
         msg = parseBinaryXVIZ(data);
         break;
+      case XVIZ_FORMAT.BINARY_PBE:
+        if (data instanceof Buffer) {
+          data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+        }
+        msg = parseBinaryXVIZ(data);
+        break;
       case XVIZ_FORMAT.JSON_BUFFER:
         let jsonString = null;
         if (data instanceof Buffer) {
@@ -141,7 +148,9 @@ export class XVIZData {
           data = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
         }
 
-        if (isGLBXVIZ(data)) {
+        if (isPBEXVIZ(data)) {
+          this._dataFormat = XVIZ_FORMAT.BINARY_PBE;
+        } else if (isGLBXVIZ(data)) {
           this._dataFormat = XVIZ_FORMAT.BINARY_GLB;
         } else {
           if (data instanceof ArrayBuffer) {

--- a/modules/io/src/index.js
+++ b/modules/io/src/index.js
@@ -13,10 +13,12 @@
 // limitations under the License.
 export {XVIZJSONWriter} from './writers/xviz-json-writer';
 export {XVIZBinaryWriter, encodeBinaryXVIZ} from './writers/xviz-binary-writer';
+export {XVIZProtobufWriter} from './writers/xviz-protobuf-writer';
 export {XVIZFormatWriter} from './writers/xviz-format-writer';
 
 export {XVIZJSONReader} from './readers/xviz-json-reader';
 export {XVIZBinaryReader} from './readers/xviz-binary-reader';
+export {XVIZProtobufReader} from './readers/xviz-protobuf-reader';
 
 export {MemorySourceSink} from './io/memory-source-sink';
 
@@ -35,12 +37,17 @@ export {
   isBinaryXVIZ,
   parseBinaryXVIZ,
   isGLBXVIZ,
+  isPBEXVIZ,
+  parsePBEXVIZ,
   isJSONString,
   getObjectXVIZType,
   getXVIZMessageType,
   isXVIZMessage
 } from './common/loaders';
 
+export {XVIZ_PROTOBUF_MESSAGE} from './common/protobuf-support';
+
 export {XVIZProviderFactory} from './providers/index';
 export {XVIZJSONProvider} from './providers/xviz-json-provider';
 export {XVIZBinaryProvider} from './providers/xviz-binary-provider';
+export {XVIZProtobufProvider} from './providers/xviz-protobuf-provider';

--- a/modules/io/src/providers/index.js
+++ b/modules/io/src/providers/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 import {XVIZJSONProvider} from './xviz-json-provider';
 import {XVIZBinaryProvider} from './xviz-binary-provider';
+import {XVIZProtobufProvider} from './xviz-protobuf-provider';
 
 async function createXVIZProvider(ProviderClass, args) {
   let provider = null;
@@ -28,7 +29,11 @@ async function createXVIZProvider(ProviderClass, args) {
 
 export class XVIZProviderFactoryClass {
   constructor() {
-    this.providerClasses = [{className: XVIZJSONProvider}, {className: XVIZBinaryProvider}];
+    this.providerClasses = [
+      {className: XVIZJSONProvider},
+      {className: XVIZBinaryProvider},
+      {className: XVIZProtobufProvider}
+    ];
   }
 
   addProviderClass(className, args) {

--- a/modules/io/src/providers/xviz-protobuf-provider.js
+++ b/modules/io/src/providers/xviz-protobuf-provider.js
@@ -11,18 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export const XVIZ_FORMAT = Object.freeze({
-  // Binary GLB enocded in Buffer/ArrayBuffer
-  BINARY_GLB: 'BINARY_GLB',
-  // Protobuf encoded in a Buffer/ArrayBuffer
-  BINARY_PBE: 'BINARY_PBE',
-  // JSON encoded in a Buffer/ArrayBuffer
-  JSON_BUFFER: 'JSON_BUFFER',
-  // JSON encoded in a String
-  JSON_STRING: 'JSON_STRING',
-  // XVIZ Object
-  OBJECT: 'OBJECT'
-});
+import {XVIZProtobufReader} from '@xviz/io';
+import {XVIZBaseProvider} from './xviz-base-provider';
 
-export const XVIZ_MESSAGE_NAMESPACE = 'xviz';
-export const XVIZ_GLTF_EXTENSION = 'AVS_xviz';
+export class XVIZProtobufProvider extends XVIZBaseProvider {
+  constructor(params) {
+    super({...params, reader: new XVIZProtobufReader(params.source, params.options)});
+  }
+}

--- a/modules/io/src/readers/xviz-protobuf-reader.js
+++ b/modules/io/src/readers/xviz-protobuf-reader.js
@@ -11,18 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-export const XVIZ_FORMAT = Object.freeze({
-  // Binary GLB enocded in Buffer/ArrayBuffer
-  BINARY_GLB: 'BINARY_GLB',
-  // Protobuf encoded in a Buffer/ArrayBuffer
-  BINARY_PBE: 'BINARY_PBE',
-  // JSON encoded in a Buffer/ArrayBuffer
-  JSON_BUFFER: 'JSON_BUFFER',
-  // JSON encoded in a String
-  JSON_STRING: 'JSON_STRING',
-  // XVIZ Object
-  OBJECT: 'OBJECT'
-});
+import {XVIZBaseReader} from './xviz-base-reader';
 
-export const XVIZ_MESSAGE_NAMESPACE = 'xviz';
-export const XVIZ_GLTF_EXTENSION = 'AVS_xviz';
+export class XVIZProtobufReader extends XVIZBaseReader {
+  constructor(source, options = {}) {
+    super(source, {...options, suffix: '-frame.pbe'});
+  }
+}

--- a/modules/io/src/writers/xviz-format-writer.js
+++ b/modules/io/src/writers/xviz-format-writer.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import {XVIZBinaryWriter} from '../writers/xviz-binary-writer';
+import {XVIZProtobufWriter} from '../writers/xviz-protobuf-writer';
 import {XVIZJSONWriter} from '../writers/xviz-json-writer';
 import {XVIZ_FORMAT} from '../common/constants';
 
@@ -27,6 +28,9 @@ function determineWriter(sink, format, options) {
   switch (format) {
     case XVIZ_FORMAT.BINARY_GLB:
       writer = new XVIZBinaryWriter(sink, options);
+      break;
+    case XVIZ_FORMAT.BINARY_PBE:
+      writer = new XVIZProtobufWriter(sink, options);
       break;
     case XVIZ_FORMAT.JSON_BUFFER:
       writer = new XVIZJSONBufferWriter(sink, options);

--- a/modules/io/src/writers/xviz-protobuf-writer.js
+++ b/modules/io/src/writers/xviz-protobuf-writer.js
@@ -1,0 +1,248 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/* eslint-disable */
+import {XVIZBaseWriter} from './xviz-base-writer';
+import {XVIZ_PROTOBUF_MAGIC, XVIZ_PROTOBUF_MESSAGE} from '../common/protobuf-support';
+
+// 0-frame is an index file for timestamp metadata
+// 1-frame is the metadata file for the log
+// 2-frame is where the actual XVIZ updates begin
+const messageName = index => `${index + 2}-frame`;
+
+export class XVIZProtobufWriter extends XVIZBaseWriter {
+  constructor(sink, options = {}) {
+    super(sink);
+
+    const {envelope = true} = options;
+    this.messageTimings = {
+      messages: new Map()
+    };
+    this.wroteMessageIndex = null;
+    this.options = {envelope};
+  }
+
+  // xvizMetadata is the object returned
+  // from a Builder.
+  writeMetadata(xvizMetadata) {
+    this._checkValid();
+    this._saveTimestamp(xvizMetadata);
+
+    const pbJSON = xvizConvertProtobuf(xvizMetadata);
+    let pbType = XVIZ_PROTOBUF_MESSAGE.Metadata;
+    let pbMsg = pbType.fromObject(pbJSON);
+
+    if (this.options.envelope) {
+      const value = pbType.encode(pbMsg).finish();
+      pbType = XVIZ_PROTOBUF_MESSAGE.Envelope;
+      pbMsg = pbType.fromObject({
+        type: 'xviz/metadata',
+        data: {type_url: 'xviz.v2.Metadata', value}
+      });
+    }
+
+    const pbBuffer = pbType.encode(pbMsg).finish();
+    const buffer = new Uint8Array(pbBuffer.byteLength + 4);
+    buffer.set(XVIZ_PROTOBUF_MAGIC, 0);
+    buffer.set(pbBuffer, 4);
+    this.writeToSink('1-frame.pbe', buffer);
+  }
+
+  writeMessage(messageIndex, xvizMessage) {
+    this._checkValid();
+    this._saveTimestamp(xvizMessage, messageIndex);
+
+    const pbJSON = xvizConvertProtobuf(xvizMessage);
+    let pbType = XVIZ_PROTOBUF_MESSAGE.StateUpdate;
+    let pbMsg = pbType.fromObject(pbJSON);
+
+    if (this.options.envelope) {
+      const value = pbType.encode(pbMsg).finish();
+      pbType = XVIZ_PROTOBUF_MESSAGE.Envelope;
+      pbMsg = pbType.fromObject({
+        type: 'xviz/state_update',
+        data: {type_url: 'xviz.v2.StateUpdate', value}
+      });
+    }
+
+    const pbBuffer = pbType.encode(pbMsg).finish();
+    const buffer = new Uint8Array(pbBuffer.byteLength + 4);
+    buffer.set(XVIZ_PROTOBUF_MAGIC, 0);
+    buffer.set(pbBuffer, 4);
+    this.writeToSink(`${messageName(messageIndex)}.pbe`, buffer);
+  }
+
+  _writeMessageIndex() {
+    this._checkValid();
+    const {startTime, endTime, messages} = this.messageTimings;
+    const messageTimings = {};
+
+    if (startTime) {
+      messageTimings.startTime = startTime;
+    }
+
+    if (endTime) {
+      messageTimings.endTime = endTime;
+    }
+
+    // Sort messages by index before writing out as an array
+    const messageTimes = Array.from(messages.keys()).sort((a, b) => a - b);
+
+    const timing = [];
+    messageTimes.forEach((value, index) => {
+      // Value is two greater than message index
+      const limit = timing.length;
+      if (value > limit) {
+        // Adding 2 because 1-frame is metadata file, so message data starts at 2
+        throw new Error(
+          `Error writing time index file. Messages are missing between ${limit + 2} and ${value +
+            2}`
+        );
+      }
+
+      timing.push(messages.get(value));
+    });
+    messageTimings.timing = timing;
+
+    const msg = JSON.stringify(messageTimings);
+    this.writeToSink('0-frame.json', msg);
+    this.wroteMessageIndex = timing.length;
+  }
+
+  close() {
+    if (this.sink) {
+      if (!this.wroteMessageIndex) {
+        this._writeMessageIndex();
+      }
+
+      super.close();
+    }
+  }
+
+  /* eslint-disable camelcase */
+  _saveTimestamp(xviz_data, index) {
+    const {log_info, updates} = xviz_data;
+
+    if (index === undefined) {
+      // Metadata case
+      if (log_info) {
+        const {start_time, end_time} = log_info || {};
+        if (start_time) {
+          this.messageTimings.startTime = start_time;
+        }
+
+        if (end_time) {
+          this.messageTimings.endTime = end_time;
+        }
+      }
+    } else if (updates) {
+      if (updates.length === 0 || !updates.every(update => typeof update.timestamp === 'number')) {
+        throw new Error('XVIZ updates did not contain a valid timestamp');
+      }
+
+      const min = Math.min(updates.map(update => update.timestamp));
+      const max = Math.max(updates.map(update => update.timestamp));
+
+      this.messageTimings.messages.set(index, [min, max, index, messageName(index)]);
+    } else {
+      // Missing updates & index is invalid call
+      throw new Error('Cannot find timestamp');
+    }
+  }
+  /* eslint-enable camelcase */
+
+  writeToSink(name, msg) {
+    this.sink.writeSync(name, msg);
+  }
+}
+
+const COLOR_KEYS = ['stroke_color', 'fill_color'];
+/* Convert color to a flattened array */
+function toColorArray(object) {
+  const clrs = object.substring(1);
+  const len = clrs.length;
+  if (!(len === 3 || len === 4 || len === 6 || len === 8)) {
+    return null;
+  }
+
+  const color = [];
+  const step = clrs.length === 3 || clrs.length === 4 ? 1 : 2;
+  for (let i = 0; i < clrs.length; i += step) {
+    color.push(parseInt(clrs.substr(i, step), 16));
+  }
+
+  return color;
+}
+
+// Recursively walk object performing the following conversions
+// - primitives with typed array fields are turned into arrays
+// - primtives of type image have the data turned into a base64 string
+/* eslint-disable complexity, no-else-return, max-statements */
+export function xvizConvertProtobuf(object, keyName) {
+  if (Array.isArray(object)) {
+    if (!(keyName === 'vertices' || keyName === 'points' || keyName === 'colors')) {
+      return object.map(element => xvizConvertProtobuf(element, keyName));
+    }
+
+    // Handle the following cases
+    // [ [x, y, z], [x, y, z], ...]
+    // [ TypedArray{x, y, z}, TypedArray{x, y ,z} ]
+    // [ x, y, z, x, y, z, ... ]
+    // [ {}, {}, ... ]
+    if (Array.isArray(object[0])) {
+      const flat = [];
+      object.forEach(el => flat.push(...el));
+      return flat;
+    } else if (ArrayBuffer.isView(object[0])) {
+      const flat = [];
+      object.forEach(el => flat.push(...Array.from(el)));
+      return flat;
+    } else if (Number.isFinite(object[0])) {
+      return object;
+    } else if (typeof object[0] === 'object') {
+      return object.map(element => xvizConvertProtobuf(element, keyName));
+    }
+  }
+
+  // Typed arrays become normal arrays
+  if (ArrayBuffer.isView(object)) {
+    return Array.from(object);
+  }
+
+  if (COLOR_KEYS.includes(keyName)) {
+    if (typeof object === 'string' && object.match(/^#([0-9a-f]{3,4})|([0-9a-f]{6,8})$/i)) {
+      return toColorArray(object);
+    }
+  }
+
+  if (object !== null && typeof object === 'object') {
+    // Handle XVIZ Image Primitive
+    const properties = Object.keys(object);
+    if (properties.includes('data') && keyName === 'images') {
+      // TODO: should verify it is a typed array and if not convert it to one
+      return object;
+    }
+
+    // Handle all other objects
+    const newObject = {};
+    const objectKeys = Object.keys(object);
+    for (const key of objectKeys) {
+      // console.log(key)
+      newObject[key] = xvizConvertProtobuf(object[key], key);
+    }
+    return newObject;
+  }
+
+  return object;
+}
+/* eslint-enable complexity */

--- a/test/modules/io/writers/index.js
+++ b/test/modules/io/writers/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import './xviz-writer.spec.js';
+import './xviz-protobuf-writer.spec.js';
 import './xviz-writer-points.spec.js';
 import './xviz-encode-parse.spec.js';
 import './xviz-format-writer.spec.js';

--- a/test/modules/io/writers/xviz-protobuf-writer.spec.js
+++ b/test/modules/io/writers/xviz-protobuf-writer.spec.js
@@ -1,0 +1,142 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/* eslint-disable camelcase, no-unused-vars */
+import test from 'tape-catch';
+import {XVIZProtobufWriter, XVIZData, MemorySourceSink} from '@xviz/io';
+import {XVIZ_PROTOBUF_MESSAGE} from '@xviz/io';
+
+//
+//  Test data and cases for successful writer tests
+//
+const SAMPLE_METADATA = {
+  version: '2.0',
+  log_info: {
+    start_time: 1,
+    end_time: 2
+  }
+};
+
+const SAMPLE_STATE_UPDATE = {
+  updates: [
+    {
+      timestamp: 100
+    }
+  ]
+};
+
+test('XVIZProtobufWriter#validate', t => {
+  t.equals(
+    XVIZ_PROTOBUF_MESSAGE.Metadata.verify(SAMPLE_METADATA),
+    null,
+    'No error verifying metadata'
+  );
+  t.equals(
+    XVIZ_PROTOBUF_MESSAGE.StateUpdate.verify(SAMPLE_STATE_UPDATE),
+    null,
+    'No error verifying state_update'
+  );
+  t.end();
+});
+
+const PRIMARY_POSE_STREAM = '/vehicle_pose';
+const DEFAULT_POSE = {
+  timestamp: 1.0,
+  map_origin: {longitude: 1.1, latitude: 2.2, altitude: 3.3},
+  position: [11, 22, 33],
+  orientation: [0.11, 0.22, 0.33]
+};
+
+function makeFrame(points, colors) {
+  return {
+    update_type: 'snapshot',
+    updates: [
+      {
+        timestamp: 1.0,
+        poses: {
+          [PRIMARY_POSE_STREAM]: DEFAULT_POSE
+        },
+        primitives: {
+          '/test/points': {
+            points: [
+              {
+                base: {
+                  object_id: '1'
+                },
+                points,
+                colors
+              }
+            ]
+          }
+        }
+      }
+    ]
+  };
+}
+
+// When XVIZData is passed an Uint8Array the magic checks expect a
+// arraybuffer to pass to the dataview, not a typed array
+test.skip('XVIZProtobufWriter#points', t => {
+  const points_flat = [1, 1, 1, 2, 2, 2, 3, 3, 3];
+  const colors_flat = [10, 10, 10, 255, 20, 20, 20, 255, 30, 30, 30, 255];
+
+  const points_nested = [[1, 1, 1], [2, 2, 2], [3, 3, 3]];
+  const colors_nested = [[10, 10, 10, 255], [20, 20, 20, 255], [30, 30, 30, 255]];
+
+  const points_typed = Float32Array.from([1, 1, 1, 2, 2, 2, 3, 3, 3]);
+  const colors_typed = Uint8Array.from([10, 10, 10, 255, 20, 20, 20, 255, 30, 30, 30, 255]);
+
+  const points_typed_nested = [
+    Float32Array.from([1, 1, 1]),
+    Float32Array.from([2, 2, 2]),
+    Float32Array.from([3, 3, 3])
+  ];
+  const colors_typed_nested = [
+    Uint8Array.from([10, 10, 10, 255]),
+    Uint8Array.from([20, 20, 20, 255]),
+    Uint8Array.from([30, 30, 30, 255])
+  ];
+
+  // Generate a frame with specific points and colors
+  [
+    makeFrame(points_flat, colors_flat),
+    makeFrame(points_nested, colors_nested),
+    makeFrame(points_typed, colors_typed),
+    makeFrame(points_typed_nested, colors_typed_nested)
+  ].forEach(frame => {
+    // Test that each "points" field is properly replaced.
+    const sink = new MemorySourceSink();
+    const writer = new XVIZProtobufWriter(sink);
+
+    writer.writeMessage(0, frame);
+
+    t.ok(sink.has('2-frame.pbe'), 'wrote binary frame');
+
+    const data = sink.readSync('2-frame.pbe');
+    const msg = new XVIZData(data).message();
+    const writtenPoints = msg.data.updates[0].primitives['/test/points'].points[0];
+
+    t.ok(writtenPoints.points, 'Has points');
+    t.ok(writtenPoints.colors, 'Has colors');
+
+    t.equals(writtenPoints.points[0], 1, 'point 1 matches input data');
+    t.equals(writtenPoints.points[3], 2, 'point 2 matches input data');
+    t.equals(writtenPoints.points[6], 3, 'point 3  matches input data');
+
+    t.equals(writtenPoints.colors[0], 10, 'color 1 matches input data');
+    t.equals(writtenPoints.colors[4], 20, 'color 2 matches input data');
+    t.equals(writtenPoints.colors[8], 30, 'color 3 matches input data');
+  });
+  t.end();
+});
+/* eslint-enable complexity */


### PR DESCRIPTION
- Initial support for a file with a magic header `PBE1` followed by our protobuf envelope and other types.
- Enumerations are not handled most efficiently so we are converting to a Javascript Object at a performance penalty in this change.  Will address in a follow-up
- Primitive color is normalized to an array of bytes prior to encoding in Protobuf.  This creates some roundtrip testing issues.  The plan is to change color in a follow-up to `bytes`.
- We have a custom protobuf.js module that can decode arrays to TypedArrays, which will be addressed in a follow-up