### PR TITLE
Protobuf changes for protobuf.js instances

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,3 +1,6 @@
 {
-  "extends": "node_modules/ocular-dev-tools/templates/.nycrc"
+  "extends": "node_modules/ocular-dev-tools/templates/.nycrc",
+  "exclude": [
+    "examples/*"
+  ]
 }

--- a/modules/builder/src/builders/xviz-metadata-builder.js
+++ b/modules/builder/src/builders/xviz-metadata-builder.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Note: XVIZ data structures use snake_case
-/* eslint-disable camelcase*/
+/* eslint-disable camelcase */
 import {_Pose as Pose, Matrix4} from 'math.gl';
 import {CATEGORY} from './constant';
 
@@ -59,7 +59,16 @@ export default class XVIZMetadataBuilder {
       metadata.log_info = this.tmp_log_info;
     }
     if (this.tmp_ui_builder) {
-      metadata.ui_config = this.tmp_ui_builder.getUI();
+      const panels = this.tmp_ui_builder.getUI();
+      metadata.ui_config = {};
+
+      // Wrap the individual panels in the ui_panel_info structure
+      for (const panelKey of Object.keys(panels)) {
+        metadata.ui_config[panelKey] = {
+          name: panels[panelKey].name,
+          config: panels[panelKey]
+        };
+      }
     }
 
     return metadata;

--- a/modules/io/src/common/loaders.js
+++ b/modules/io/src/common/loaders.js
@@ -16,7 +16,7 @@ import {GLTFParser} from '@loaders.gl/gltf';
 
 import {XVIZ_GLTF_EXTENSION} from './constants';
 import {TextDecoder} from './text-encoding';
-import {MAGIC_PBE1, XVIZ_PROTOBUF_MESSAGE} from './protobuf-support';
+import {MAGIC_PBE1, XVIZ_PROTOBUF_MESSAGE, XVIZ_PROTOBUF_TYPE} from './protobuf-support';
 import {Enum, Type, MapField} from 'protobufjs';
 
 // XVIZ Type constants
@@ -199,6 +199,14 @@ function getPBEXVIZType(arrayBuffer) {
   return envelope.type;
 }
 
+function postProcessUIConfig(msg) {
+  if (msg && msg.ui_config) {
+    for (const entry of Object.keys(msg.ui_config)) {
+      msg.ui_config[entry] = XVIZ_PROTOBUF_TYPE.UIPanelInfo.toObject(msg.ui_config[entry]);
+    }
+  }
+}
+
 /* We need to modify the protobufjs objects to work closer to "normal"
  * Javascript objects. The protobuf type reflection is available as `msg.$type`
  * which is traversed in parallel to the `msg`.
@@ -285,6 +293,7 @@ export function parsePBEXVIZ(arrayBuffer) {
     case 'xviz/metadata':
       const tmpMeta = XVIZ_PROTOBUF_MESSAGE.Metadata.decode(envelope.data.value);
       xviz.data = postProcessProtobuf(tmpMeta);
+      postProcessUIConfig(xviz.data);
       break;
     case 'xviz/state_update':
       const tmpState = XVIZ_PROTOBUF_MESSAGE.StateUpdate.decode(envelope.data.value);

--- a/modules/io/src/common/loaders.js
+++ b/modules/io/src/common/loaders.js
@@ -17,6 +17,7 @@ import {GLTFParser} from '@loaders.gl/gltf';
 import {XVIZ_GLTF_EXTENSION} from './constants';
 import {TextDecoder} from './text-encoding';
 import {MAGIC_PBE1, XVIZ_PROTOBUF_MESSAGE} from './protobuf-support';
+import {Enum, Type, MapField} from 'protobufjs';
 
 // XVIZ Type constants
 const XVIZ_TYPE_PATTERN = /"type":\s*"(xviz\/\w*)"/;
@@ -198,6 +199,78 @@ function getPBEXVIZType(arrayBuffer) {
   return envelope.type;
 }
 
+/* We need to modify the protobufjs objects to work closer to "normal"
+ * Javascript objects. The protobuf type reflection is available as `msg.$type`
+ * which is traversed in parallel to the `msg`.
+ *
+ * The following mutations are made:
+ *
+ * - Remove empty Arrays from the instance, protobuf.js will set to the default value: [] (the empty array)
+ * - Enum => String
+ * - Handle arrays of enum
+ * - Recursive on objects
+ */
+/* eslint-disable max-depth, complexity */
+function postProcessProtobuf(msg, pbType) {
+  const type = pbType || msg.$type;
+
+  if (msg && type && type.fields) {
+    const fields = type.fields;
+
+    for (const fieldName in fields) {
+      const field = fields[fieldName];
+
+      if (field && msg[field.name]) {
+        if (!field.resolvedType && field.repeated && msg[field.name].length === 0) {
+          // Remove empty arrays that are likely the default value
+          msg[field.name] = undefined;
+          delete msg[field.name];
+        } else if (field.resolvedType) {
+          // Handle integer enum to string change
+          if (field.resolvedType instanceof Enum) {
+            if (field.repeated) {
+              if (msg[field.name].length === 0) {
+                // Remove empty arrays that are likely the default value
+                msg[field.name] = undefined;
+                delete msg[field.name];
+              } else {
+                // Map array of enums to strings using reflection information
+                msg[field.name] = msg[field.name].map(
+                  entry => field.resolvedType.valuesById[entry]
+                );
+              }
+            } else {
+              // Map enums to strings using reflection information
+              msg[field.name] = field.resolvedType.valuesById[msg[field.name]];
+            }
+          } else if (field instanceof MapField) {
+            // Recursive processing on key,value field
+            for (const key of Object.keys(msg[field.name])) {
+              msg[field.name][key] = postProcessProtobuf(msg[field.name][key], field.resolvedType);
+            }
+          } else if (field.resolvedType instanceof Type) {
+            // Recursive processing on fields of an object
+            if (field.repeated) {
+              if (msg[field.name].length === 0) {
+                msg[field.name] = undefined;
+                delete msg[field.name];
+              } else {
+                msg[field.name] = msg[field.name].map(entry =>
+                  postProcessProtobuf(entry, field.resolvedType)
+                );
+              }
+            } else {
+              msg[field.name] = postProcessProtobuf(msg[field.name], field.resolvedType);
+            }
+          }
+        }
+      }
+    }
+  }
+  return msg;
+}
+/* eslint-enable max-depth, complexity */
+
 // TODO: unpackEnvelop produces namespace, type data
 export function parsePBEXVIZ(arrayBuffer) {
   const strippedBuffer = new Uint8Array(arrayBuffer, 4);
@@ -210,22 +283,12 @@ export function parsePBEXVIZ(arrayBuffer) {
 
   switch (envelope.type) {
     case 'xviz/metadata':
-      // TODO: support enum integers when parsing to avoid costly toObject() call
-      // xviz.data = XVIZ_PROTOBUF_MESSAGE.Metadata.decode(envelope.data.value);
       const tmpMeta = XVIZ_PROTOBUF_MESSAGE.Metadata.decode(envelope.data.value);
-      // This toObject is required to change enums to strings for now
-      xviz.data = XVIZ_PROTOBUF_MESSAGE.Metadata.toObject(tmpMeta, {
-        enums: String
-      });
+      xviz.data = postProcessProtobuf(tmpMeta);
       break;
     case 'xviz/state_update':
-      // TODO: support enum integers when parsing to avoid costly toObject() call
-      // xviz.data = XVIZ_PROTOBUF_MESSAGE.StateUpdate.decode(envelope.data.value);
       const tmpState = XVIZ_PROTOBUF_MESSAGE.StateUpdate.decode(envelope.data.value);
-      // This toObject is required to change enums to strings for now
-      xviz.data = XVIZ_PROTOBUF_MESSAGE.StateUpdate.toObject(tmpState, {
-        enums: String
-      });
+      xviz.data = postProcessProtobuf(tmpState);
       break;
     default:
       throw new Error(`Unknown Message type ${envelope.type}`);

--- a/modules/io/src/common/protobuf-support.js
+++ b/modules/io/src/common/protobuf-support.js
@@ -1,3 +1,16 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 import {loadProtos} from '@xviz/schema';
 
 // All XVIZ messages
@@ -13,6 +26,10 @@ export const XVIZ_PROTOBUF_MESSAGE_NAME = {
   ERROR: 'xviz.v2.Error'
 };
 
+export const XVIZ_PROTOBUF_TYPE_NAME = {
+  UI_PANEL_INFO: 'xviz.v2.UIPanelInfo'
+};
+
 // PBE1
 export const MAGIC_PBE1 = 0x50424531;
 export const XVIZ_PROTOBUF_MAGIC = Uint8Array.from([0x50, 0x42, 0x45, 0x31]);
@@ -23,4 +40,8 @@ export const XVIZ_PROTOBUF_MESSAGE = {
   Envelope: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_MESSAGE_NAME.ENVELOPE),
   Metadata: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_MESSAGE_NAME.METADATA),
   StateUpdate: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_MESSAGE_NAME.STATE_UPDATE)
+};
+
+export const XVIZ_PROTOBUF_TYPE = {
+  UIPanelInfo: XVIZ_PROTOBUF_ROOT.lookupType(XVIZ_PROTOBUF_TYPE_NAME.UI_PANEL_INFO)
 };

--- a/modules/io/src/io/memory-source-sink.js
+++ b/modules/io/src/io/memory-source-sink.js
@@ -24,7 +24,14 @@ export class MemorySourceSink {
   }
 
   writeSync(name, data) {
-    this.data.set(name, data);
+    // Save the underlying arrayBuffer not the TypedArray
+    // because when reading we should have an ArrayBuffer
+    // and the consumer should make the Type decision
+    if (ArrayBuffer.isView(data) && data.length && data.buffer) {
+      this.data.set(name, data.buffer);
+    } else {
+      this.data.set(name, data);
+    }
   }
 
   close() {}

--- a/modules/io/src/writers/xviz-protobuf-writer.js
+++ b/modules/io/src/writers/xviz-protobuf-writer.js
@@ -45,7 +45,7 @@ export class XVIZProtobufWriter extends XVIZBaseWriter {
     };
 
     if (this.options.envelope) {
-      pbInfo = this._applyEnvelope(pbInfo);
+      this._applyEnvelope(pbInfo);
     }
 
     const pbBuffer = pbInfo.type.encode(pbInfo.msg).finish();
@@ -66,7 +66,7 @@ export class XVIZProtobufWriter extends XVIZBaseWriter {
     };
 
     if (this.options.envelope) {
-      pbInfo = this._applyEnvelope(pbInfo);
+      this._applyEnvelope(pbInfo);
     }
 
     const pbBuffer = pbInfo.type.encode(pbInfo.msg).finish();

--- a/modules/parser/src/styles/stylesheet.js
+++ b/modules/parser/src/styles/stylesheet.js
@@ -34,7 +34,7 @@ export default class Stylesheet {
 
     this.properties = {};
     rules.forEach(rule => {
-      for (const key in rule.properties) {
+      for (const key of Object.keys(rule.properties)) {
         let p = this.properties[key];
         if (!p) {
           p = [];
@@ -57,8 +57,12 @@ export default class Stylesheet {
    */
   getProperty(propertyName, state = {}) {
     // inline style override any generic rules
-    const inlineProp = state.base && state.base.style && state.base.style[propertyName];
-    if (inlineProp !== undefined) {
+    const inlineProp =
+      state.base &&
+      state.base.style &&
+      state.base.style.hasOwnProperty(propertyName) &&
+      state.base.style[propertyName];
+    if (inlineProp !== undefined && inlineProp !== null && inlineProp !== false) {
       return XVIZStyleProperty.formatValue(propertyName, inlineProp);
     }
 
@@ -149,7 +153,7 @@ export default class Stylesheet {
   _parseProperties(properties) {
     const result = {};
 
-    for (const key in properties.style) {
+    for (const key of Object.keys(properties.style)) {
       result[key] = new XVIZStyleProperty(key, properties.style[key]);
     }
     return result;

--- a/modules/parser/src/styles/xviz-style-property.js
+++ b/modules/parser/src/styles/xviz-style-property.js
@@ -32,6 +32,10 @@ function getColor(value) {
   if (Array.isArray(value) && Number.isFinite(value[0])) {
     return value;
   }
+  if (ArrayBuffer.isView(value) && Number.isFinite(value[0])) {
+    return value;
+  }
+
   return null;
 }
 

--- a/test/modules/builder/builders/xviz-metadata-builder.spec.js
+++ b/test/modules/builder/builders/xviz-metadata-builder.spec.js
@@ -268,7 +268,7 @@ test('XVIZMetadataBuilder#ui', t => {
   const expected = {
     version: '2.0.0',
     streams: {},
-    ui_config: {Metrics: {type: 'PANEL', name: 'Metrics'}}
+    ui_config: {Metrics: {name: 'Metrics', config: {type: 'PANEL', name: 'Metrics'}}}
   };
   t.deepEqual(metadata, expected, 'XVIZMetadataBuilder build matches expected output');
 

--- a/test/modules/io/common/index.js
+++ b/test/modules/io/common/index.js
@@ -12,3 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import './xviz-data.spec';
+import './loaders.spec';

--- a/test/modules/io/common/loaders.spec.js
+++ b/test/modules/io/common/loaders.spec.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import tape from 'tape-catch';
+
+import {parseBinaryXVIZ, XVIZBinaryWriter, XVIZProtobufWriter, MemorySourceSink} from '@xviz/io';
+import {generateTestData} from './test-data-generator';
+
+const TestData = new MemorySourceSink();
+const pbeWriter = new XVIZProtobufWriter(TestData);
+const glbWriter = new XVIZBinaryWriter(TestData);
+
+// Generate test data using a builder for GLB & PBE
+generateTestData(pbeWriter);
+generateTestData(glbWriter);
+
+// Verify the parsed data fields are accessible
+// Specifically for PBE:
+// - enums are string
+// - metadata ui_config is an object per the spec
+tape('parseBinaryXVIZ#metadata', t => {
+  t.ok(TestData.has('1-frame.pbe'), 'PBE Metadata exists');
+  t.ok(TestData.has('1-frame.glb'), 'GLB Metadata exists');
+
+  const pbe = TestData.readSync('1-frame.pbe');
+  const glb = TestData.readSync('1-frame.glb');
+
+  const metaPBE = parseBinaryXVIZ(pbe);
+  const metaGLB = parseBinaryXVIZ(glb);
+
+  [metaPBE, metaGLB].forEach(meta => {
+    t.equals('xviz/metadata', meta.type, 'Decoded type is correct');
+    t.ok(meta.data.streams['/vehicle_pose'], 'Stream metadata present');
+    t.equals(
+      meta.data.streams['/vehicle_pose'].category,
+      'POSE',
+      'Stream metadata category is correct and a string'
+    );
+    t.equals(meta.data.ui_config.Metrics.name, 'Metrics', 'ui_config "Metrics" panel is present');
+    t.equals(meta.data.log_info.start_time, 1000.1, 'Metadata start_time entry correct');
+  });
+
+  t.end();
+});
+
+tape('parseBinaryXVIZ#stateUpdate', t => {
+  t.ok(TestData.has('2-frame.pbe'), 'PBE stateUpdate exists');
+  t.ok(TestData.has('2-frame.glb'), 'GLB stateUpdate exists');
+
+  const pbe = TestData.readSync('2-frame.pbe');
+  const glb = TestData.readSync('2-frame.glb');
+
+  const statePBE = parseBinaryXVIZ(pbe);
+  const stateGLB = parseBinaryXVIZ(glb);
+
+  [statePBE, stateGLB].forEach(meta => {
+    t.equals('xviz/state_update', meta.type, 'Decoded type is correct');
+    t.equals(meta.data.update_type, 'SNAPSHOT', 'Update Type is correct');
+    t.ok(meta.data.updates[0].poses['/vehicle_pose'], 'Pose is present');
+    t.equals(
+      meta.data.updates[0].time_series[0].streams[0],
+      '/vehicle/acceleration',
+      'time_series data is present'
+    );
+    t.deepEquals(
+      Array.from(meta.data.updates[0].primitives['/objects'].polygons[0].vertices),
+      [1, 1, 1, 3, 3, 3, 4, 4, 4],
+      'polygon vertices are correct'
+    );
+  });
+
+  t.end();
+});

--- a/test/modules/io/common/test-data-generator.js
+++ b/test/modules/io/common/test-data-generator.js
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/* eslint-disable camelcase */
+import {XVIZBuilder, XVIZMetadataBuilder, XVIZUIBuilder} from '@xviz/builder';
+
+// Creates a panel, container, metric, plot, and video
+function generateTestUI(uiBuilder) {
+  const panel = uiBuilder.panel({
+    name: 'Metrics'
+  });
+
+  const container = uiBuilder.container({
+    name: 'Metrics Panel',
+    layout: 'vertical',
+    interactions: ['REORDERABLE', 'DRAG_OUT']
+  });
+  panel.child(container);
+
+  const metricAcceleration = uiBuilder.metric({
+    title: 'Acceleration',
+    streams: ['/vehicle/acceleration'],
+    description: 'The acceleration of the vehicle'
+  });
+  container.child(metricAcceleration);
+
+  const plot = uiBuilder.plot({
+    title: 'Cost',
+    description: 'Costs considered in planning the vehicle trajectory',
+    independentVariable: '/motion_planning/time',
+    dependentVariables: [
+      '/motion_planning/trajectory/cost/cost1',
+      '/motion_planning/trajectory/cost/cost2',
+      '/motion_planning/trajectory/cost/cost3'
+    ]
+  });
+  container.child(plot);
+
+  const video = uiBuilder.video({
+    cameras: ['/camera/image_00', '/camera/image_01', '/camera/image_02', '/camera/image_03']
+  });
+  container.child(video);
+
+  return panel;
+}
+
+export function generateTestData(xvizWriter) {
+  const uiBuilder = new XVIZUIBuilder();
+  uiBuilder.child(generateTestUI(uiBuilder));
+
+  const metaBuilder = new XVIZMetadataBuilder();
+  metaBuilder.ui(uiBuilder);
+  metaBuilder.startTime(1000.1);
+  metaBuilder.endTime(1005.3);
+  metaBuilder
+    .stream('/vehicle_pose')
+    .category('pose')
+
+    .stream('/vehicle/acceleration')
+    .category('time_series')
+    .type('float')
+    .unit('m/s^2')
+
+    .stream('/objects')
+    .category('primitive')
+    .type('polygon')
+    .streamStyle({
+      stroke_color: '#AABBCC',
+      stroke_width: 1.4
+    });
+
+  xvizWriter.writeMetadata(metaBuilder.getMetadata());
+
+  const builder = new XVIZBuilder();
+  builder
+    .pose('/vehicle_pose')
+    .timestamp(1000.1)
+    .mapOrigin(0, 0, 0);
+
+  builder
+    .timeSeries('/vehicle/acceleration')
+    .timestamp(1000.1)
+    .value(10.7);
+
+  builder.primitive('/objects').polygon([1, 1, 1, 3, 3, 3, 4, 4, 4]);
+
+  xvizWriter.writeMessage(0, builder.getMessage());
+}

--- a/test/modules/io/writers/xviz-format-writer.spec.js
+++ b/test/modules/io/writers/xviz-format-writer.spec.js
@@ -65,7 +65,8 @@ tape('XVIZFormatWriter#full matrix', t => {
       // We don't really care about the key as each writer will have
       // different identifier, (eg: 1-frame.json vs 1.frame.glb)
       for (const [key, val] of sink.entries()) {
-        t.ok(val.length, `${key} has formatted data`);
+        // Cover Arrays, Strings, ArrayBuffers
+        t.ok(val.byteLength || val.length, `${key} has formatted data`);
 
         // Verify the data is parsed as the expected format
         const newObj = new XVIZData(val);

--- a/xviz/v2/session.proto
+++ b/xviz/v2/session.proto
@@ -18,7 +18,6 @@ import "google/protobuf/struct.proto";
 import "xviz/v2/core.proto";
 import "xviz/v2/options.proto";
 import "xviz/v2/style.proto";
-import "xviz/v2/panel.proto";
 
 // NOTE: this enum purposely not scoped inside Start to avoid naming conflict
 // with "log" field and "log" type


### PR DESCRIPTION
Protobuf.js uses prototype object creation which has the effect of
looking up the prototype chain for properties even if the instance
does not have it set.
    
This requires the use of 'hasOwnProperty()' in some places to
distinguish between the instance and the prototype property.
    
The library also assigns default values for fields, such as the
empty array or a value of 0. Our parsing would look at presences
to determine if a property was meaningfully set, but now we need to
have additional validation due to the default values set by the
protobuf.js library.

