### PR TITLE
Unify the handling of no-data entries

### DIFF
--- a/modules/parser/src/parsers/parse-timeslice-data-v2.js
+++ b/modules/parser/src/parsers/parse-timeslice-data-v2.js
@@ -97,6 +97,7 @@ function parseStreamSets(streamSets, timestamp, convertPrimitive) {
   const timeSeries = [];
   const futures = {};
   const uiPrimitives = {};
+  const noDataStreams = [];
 
   for (const streamSet of streamSets) {
     Object.assign(poses, streamSet.poses);
@@ -109,6 +110,10 @@ function parseStreamSets(streamSets, timestamp, convertPrimitive) {
       if (timeSeries) {
         timeSeries.push(...streamSet.time_series);
       }
+    }
+
+    if (streamSet.no_data_streams && noDataStreams) {
+      noDataStreams.push(...streamSet.no_data_streams);
     }
   }
 
@@ -155,6 +160,11 @@ function parseStreamSets(streamSets, timestamp, convertPrimitive) {
         timestamp
       );
     });
+
+  if (noDataStreams.length) {
+    // Explicitly set to null and the stream buffer will do the right thing
+    noDataStreams.forEach(stream => (newStreams[stream] = null));
+  }
 
   return newStreams;
 }

--- a/modules/parser/src/parsers/parse-timeslice-data-v2.js
+++ b/modules/parser/src/parsers/parse-timeslice-data-v2.js
@@ -112,7 +112,7 @@ function parseStreamSets(streamSets, timestamp, convertPrimitive) {
       }
     }
 
-    if (streamSet.no_data_streams && noDataStreams) {
+    if (streamSet.no_data_streams) {
       noDataStreams.push(...streamSet.no_data_streams);
     }
   }

--- a/modules/parser/src/synchronizers/log-slice.js
+++ b/modules/parser/src/synchronizers/log-slice.js
@@ -114,7 +114,11 @@ export default class LogSlice {
     // get data if we don't already have that stream && it is not filtered.
     streamsByReverseTime.forEach(streams => {
       for (const streamName in streams) {
-        if (!this.streams[streamName] && this._includeStream(filter, streamName)) {
+        if (
+          this.streams[streamName] !== null && // Explicit no data entry
+          !this.streams[streamName] && // undefined means it has not been seen so keep looking for valid entry
+          this._includeStream(filter, streamName)
+        ) {
           this.addStreamDatum(streams[streamName], streamName, lookAheadMs, this);
         }
       }
@@ -126,6 +130,11 @@ export default class LogSlice {
    */
   addStreamDatum(datum, streamName, lookAheadMs) {
     this.streams[streamName] = datum;
+
+    // Handle the no data case
+    if (!datum) {
+      return;
+    }
 
     this.setLabelsOnXVIZObjects(datum.labels);
 

--- a/modules/parser/src/synchronizers/xviz-stream-buffer.js
+++ b/modules/parser/src/synchronizers/xviz-stream-buffer.js
@@ -384,10 +384,6 @@ export default class XVIZStreamBuffer {
 
     for (const streamName in timeslice.streams) {
       const value = timeslice.streams[streamName];
-      if (value === null) {
-        // Explicitly delete a stream
-        delete timesliceAtInsertPosition.streams[streamName];
-      }
       streams[streamName][index] = value;
     }
     for (const streamName in timeslice.videos) {

--- a/modules/parser/src/synchronizers/xviz-stream-buffer.js
+++ b/modules/parser/src/synchronizers/xviz-stream-buffer.js
@@ -383,11 +383,10 @@ export default class XVIZStreamBuffer {
     });
 
     for (const streamName in timeslice.streams) {
-      let value = timeslice.streams[streamName];
+      const value = timeslice.streams[streamName];
       if (value === null) {
         // Explicitly delete a stream
         delete timesliceAtInsertPosition.streams[streamName];
-        value = undefined;
       }
       streams[streamName][index] = value;
     }

--- a/test/modules/parser/parsers/parse-xviz-message-sync.spec.js
+++ b/test/modules/parser/parsers/parse-xviz-message-sync.spec.js
@@ -766,6 +766,42 @@ tape('parseXVIZData futures timeslice v1', t => {
   t.end();
 });
 
+tape('parseXVIZData state_update, PERSISTENT', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZConfig({currentMajorVersion: 2, ALLOW_MISSING_PRIMARY_POSE: true});
+
+  const persistentMsg = {...TestTimesliceMessageV2};
+  persistentMsg.update_type = 'PERSISTENT';
+
+  const result = parseXVIZData(persistentMsg, {v2Type: 'state_update'});
+  t.equals(result.type, XVIZ_MESSAGE_TYPE.TIMESLICE, 'Message type set for timeslice');
+  t.equal(result.updateType, 'PERSISTENT', 'XVIZ update type is parsed');
+  t.equals(result.timestamp, TestTimesliceMessageV2.updates[0].timestamp, 'Message timestamp set');
+
+  const feature = result.streams['/test/stream'].features[0];
+  t.equal(feature.type, 'point', 'feature has type point');
+  t.deepEquals(Array.from(feature.points), [1000, 1000, 200], 'feature has type point');
+
+  t.end();
+});
+
+tape('parseXVIZData state_update, no_data_streams', t => {
+  resetXVIZConfigAndSettings();
+  setXVIZConfig({currentMajorVersion: 2, ALLOW_MISSING_PRIMARY_POSE: true});
+
+  const noDataStreamMsg = {...TestTimesliceMessageV2};
+  noDataStreamMsg.updates[0].no_data_streams = ['/no-data-stream'];
+
+  const result = parseXVIZData(noDataStreamMsg, {v2Type: 'state_update'});
+  t.equals(result.type, XVIZ_MESSAGE_TYPE.TIMESLICE, 'Message type set for timeslice');
+  t.equal(result.updateType, 'COMPLETE', 'XVIZ update type is parsed');
+  t.equals(result.timestamp, TestTimesliceMessageV2.updates[0].timestamp, 'Message timestamp set');
+
+  t.equal(result.streams['/no-data-stream'], null, 'no_data_stream marked as null');
+
+  t.end();
+});
+
 tape('parseXVIZMessageSync', t => {
   resetXVIZConfigAndSettings();
   setXVIZConfig({currentMajorVersion: 2});

--- a/test/modules/parser/synchronizers/stream-synchronizer.spec.js
+++ b/test/modules/parser/synchronizers/stream-synchronizer.spec.js
@@ -168,8 +168,8 @@ tape('StreamSynchronizer#correct lookup with empty entries (explicit no-data)', 
       // start both with no-data entry
       timestamp: 90,
       streams: {
-        stream1: {},
-        stream2: {}
+        stream1: null,
+        stream2: null
       }
     },
     {
@@ -197,8 +197,8 @@ tape('StreamSynchronizer#correct lookup with empty entries (explicit no-data)', 
       // add no-data entry for both
       timestamp: 103,
       streams: {
-        stream1: {},
-        stream2: {}
+        stream1: null,
+        stream2: null
       }
     },
     {
@@ -213,8 +213,8 @@ tape('StreamSynchronizer#correct lookup with empty entries (explicit no-data)', 
       // no-data entry for both
       timestamp: 115,
       streams: {
-        stream1: {},
-        stream2: {}
+        stream1: null,
+        stream2: null
       }
     },
     {
@@ -235,14 +235,14 @@ tape('StreamSynchronizer#correct lookup with empty entries (explicit no-data)', 
       // empty entry for stream2
       timestamp: 122,
       streams: {
-        stream2: {}
+        stream2: null
       }
     }
   ];
 
   const streamSynchronizer = new StreamSynchronizer(STREAMS_WITH_NO_DATA_ENTRIES);
 
-  // Test a time before any valid entries
+  // Test a time before any valid entries and with no entries within TIME_WINDOW
   streamSynchronizer.setTime(99);
   let data = streamSynchronizer.getLogSlice();
   t.equals(data.streams.stream1, undefined, 'stream1 is undefined at time 99');
@@ -260,11 +260,11 @@ tape('StreamSynchronizer#correct lookup with empty entries (explicit no-data)', 
   t.equals(data.streams.stream1.value, 1.5, 'stream1 is 1.5 at time 102');
   t.equals(data.streams.stream2.value, 10, 'stream2 is 10 at time 102');
 
-  // Test a time that has no-data entry for both streams
+  // Test a time that has no-data entry for both streams within the time-window
   streamSynchronizer.setTime(103);
   data = streamSynchronizer.getLogSlice();
-  t.equals(data.streams.stream1.value, undefined, 'stream1 is undefined at time 103');
-  t.equals(data.streams.stream2.value, undefined, 'stream2 is undefined at time 103');
+  t.equals(data.streams.stream1, null, 'stream1 is explicitly no-data at time 103');
+  t.equals(data.streams.stream2, null, 'stream2 is explicitly no-data at time 103');
 
   // Test a both streams picked up from same entry
   streamSynchronizer.setTime(110);

--- a/test/modules/parser/synchronizers/xviz-stream-buffer.spec.js
+++ b/test/modules/parser/synchronizers/xviz-stream-buffer.spec.js
@@ -165,7 +165,7 @@ test('XVIZStreamBuffer#insert, getStreams', t => {
 
   t.deepEquals(
     xvizStreamBuffer.getStreams(),
-    {A: [1.1, 2.2, 3, 4, 5], B: [-1], C: [1]},
+    {A: [1.1, 2.2, 3, 4, 5], B: [null, -1], C: [1]},
     'getStreams returns correct result'
   );
 

--- a/test/modules/parser/synchronizers/xviz-stream-buffer.spec.js
+++ b/test/modules/parser/synchronizers/xviz-stream-buffer.spec.js
@@ -64,7 +64,7 @@ const TEST_CASES = [
       timestamp: 1001,
       streams: {A: 1.1, B: null}
     },
-    snapshot: {A: 1.1, C: 1}
+    snapshot: {A: 1.1, B: null, C: 1}
   },
   {
     id: 'TS-8',


### PR DESCRIPTION
- parser will return 'null' for no-data entries
- xviz stream buffer will handle the 'null' value appropropriately
- log slice will respect the 'null' value as a no-data entry and not keep
  searching