### PR TITLE
Update some broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,10 @@ $ ./scripts/run-kitti-example.sh
 - `lint fix` - run prettier
 - `publish beta` - publish beta release
 - `publish prod` - publish production release
+
+## Requirements for Contribution 
+The pre-commit hook `yarn test-fast` requires you to have `jq` installed: 
+
+```
+brew install jq
+```

--- a/docs/developers-guide/structure-of-xviz.md
+++ b/docs/developers-guide/structure-of-xviz.md
@@ -1,6 +1,6 @@
 # Structure of XVIZ-encoded data
 
-This is a brief summary of [XVIZ concepts](./docs/overview/concepts.md),
+This is a brief summary of [XVIZ concepts](../docs/overview/concepts.md),
 
 ## File Structure
 

--- a/docs/protocol-formats/binary-protocol.md
+++ b/docs/protocol-formats/binary-protocol.md
@@ -156,7 +156,7 @@ application needs to know how many values represent one element, for instance 3 
 
 ## References
 
-- [glTF 2 Poster](https://raw.githubusercontent.com/KhronosGroup/glTF/master/specification/2.0/figures/gltfOverview-2.0.0a.png)
+- [glTF 2 Poster](https://raw.githubusercontent.com/KhronosGroup/glTF/master/specification/2.0/figures/gltfOverview-2.0.0b.png)
 - [glTF 2 Spec](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0)
 
 ## Remarks


### PR DESCRIPTION
Some of the documentation links on the [avs.auto docs page](https://avs.auto/#/about) are broken. This PR tries to fix some. 

Also adds some info to the README. 