### PR TITLE
Fix loss of precision for polyline and polygon in parser

### DIFF
--- a/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
+++ b/modules/builder/src/writers/xviz-writer/xviz-pack-binary.js
@@ -71,6 +71,7 @@ function flattenObject(key, object) {
 
   if (key === 'vertices' || key === 'points') {
     // Flatten nested vertices
+    // TODO - loss of precision for geographic coordinates
     typedArray = flattenToTypedArray(object, size, Float32Array);
   }
   if (key === 'colors') {

--- a/modules/parser/src/parsers/parse-xviz-stream.js
+++ b/modules/parser/src/parsers/parse-xviz-stream.js
@@ -478,7 +478,7 @@ function joinFeatureVerticesToTypedArrays(features) {
     return null;
   }
 
-  const vertices = new Float32Array(vertexCount * 3);
+  const vertices = new Float64Array(vertexCount * 3);
   let i = 0;
 
   for (const feature of features) {


### PR DESCRIPTION
For https://github.com/uber/streetscape.gl/issues/385