### PR TITLE
Add "point_color_mode" and "point_color_domain" to the spec files

### DIFF
--- a/docs/protocol-schema/style-specification.md
+++ b/docs/protocol-schema/style-specification.md
@@ -169,8 +169,8 @@ Supported style properties by primitive types:
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------- | ---------- | ---------- |
 | `radius_pixels`      | The point radius in pixels                                                                                                             | Number                              | `1`                                                                   | X          |            |
 | `fill_color`         | Fill color of the point                                                                                                                | [Color](#color)                     | `'#fff'`                                                              | X          |            |
-| `point_color_mode`   | How to color point primitives                                                                                                          | [PointColorMode](#point-color-mode) | `'default'`                                                           | X          |            |
-| `point_color_domain` | The lower and upper bounds of the point measurement that maps to blue and red respectively. Only used if `point_color_mode` is defined | Array                               | `[0, 3]` in `elevation` mode, `[0, 60]` in `distance_to_vehicle` mode | X          |            |
+| `point_color_mode`   | How to color point primitives                                                                                                          | [PointColorMode](#point-color-mode) | `'DEFAULT'`                                                           | X          |            |
+| `point_color_domain` | The lower and upper bounds of the point measurement that maps to blue and red respectively. Only used if `point_color_mode` is defined | Array                               | `[0, 3]` in `ELEVATION` mode, `[0, 60]` in `DISTANCE_TO_VEHICLE` mode | X          |            |
 | `opacity`            | Opacity of the object                                                                                                                  | Number                              | `1`                                                                   | X          |            |
 
 ### polygon
@@ -235,9 +235,9 @@ Color values can be in one of the following formats:
 
 How to color `point` primitives. Can be one of 3 values:
 
-- `default` - use inline colors if provided, or `fill_colors` style otherwise
-- `elevation` - color by elevation from the ground.
-- `distance_to_vehicle` - color by distance to the vehicle.
+- `DEFAULT` - use inline colors if provided, or `fill_colors` style otherwise
+- `ELEVATION` - color by elevation from the ground.
+- `DISTANCE_TO_VEHICLE` - color by distance to the vehicle.
 
 ## Remarks
 

--- a/modules/conformance/inputs/point/style/1-frame.json
+++ b/modules/conformance/inputs/point/style/1-frame.json
@@ -43,7 +43,7 @@
         "category": "primitive",
         "primitive_type": "point",
         "stream_style": {
-          "point_color_mode": "elevation"
+          "point_color_mode": "ELEVATION"
         }
       },
 
@@ -51,7 +51,7 @@
         "category": "primitive",
         "primitive_type": "point",
         "stream_style": {
-          "point_color_mode": "distance_to_vehicle",
+          "point_color_mode": "DISTANCE_TO_VEHICLE",
           "point_color_domain": [0, 5]
         }
       }

--- a/modules/parser/src/styles/xviz-style-property.js
+++ b/modules/parser/src/styles/xviz-style-property.js
@@ -124,13 +124,16 @@ const DEFAULT_STYLES = {
   stroke_width_min_pixels: 0,
   stroke_width_max_pixels: Number.MAX_SAFE_INTEGER,
 
-  point_color_mode: 'default',
+  point_color_mode: 'DEFAULT',
   point_color_domain: stylesheet => {
-    const colorMode = stylesheet.getProperty('point_color_mode');
+    let colorMode = stylesheet.getProperty('point_color_mode');
+    if (colorMode) {
+      colorMode = colorMode.toUpperCase();
+    }
     switch (colorMode) {
-      case 'elevation':
+      case 'ELEVATION':
         return [0, 3];
-      case 'distance_to_vehicle':
+      case 'DISTANCE_TO_VEHICLE':
         return [0, 60];
       default:
         return [0, 0];

--- a/modules/schema/examples/style/stream_value/full.json
+++ b/modules/schema/examples/style/stream_value/full.json
@@ -15,5 +15,7 @@
   "opacity": 0.4,
   "stroked": false,
   "filled": true,
-  "extruded": false
+  "extruded": false,
+  "point_color_mode": "ELEVATION",
+  "point_color_domain": [0, 4]
 }

--- a/modules/schema/schema/style/stream_value.schema.json
+++ b/modules/schema/schema/style/stream_value.schema.json
@@ -70,6 +70,17 @@
       },
       "font_weight": {
         "type": "number"
+      },
+      "point_color_mode": {
+        "enum": ["ELEVATION", "DISTANCE_TO_VEHICLE"]
+      },
+      "point_color_domain": {
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 2,
+        "items": {
+          "type": "number"
+        }
       }
   },
   "anyOf": [
@@ -91,7 +102,10 @@
       {"required": ["filled"]},
       {"required": ["extruded"]},
       {"required": ["font_family"]},
-      {"required": ["font_weight"]}
+      {"required": ["font_weight"]},
+      {"required": ["point_color_mode"]},
+      {"required": ["point_color_domain"]}
+
   ],
   "additionalProperties": false
 }

--- a/test/modules/conformance/renderer/point.js
+++ b/test/modules/conformance/renderer/point.js
@@ -38,11 +38,11 @@ export default function renderPoint({context, feature, stylesheet, project}) {
     let color;
 
     switch (colorMode) {
-      case 'elevation':
+      case 'ELEVATION':
         color = getColor(vertex[2], colorDomain);
         break;
 
-      case 'distance_to_vehicle':
+      case 'DISTANCE_TO_VEHICLE':
         color = getColor(new Vector3(vertex[0], vertex[1], vertex[2]).len(), colorDomain);
         break;
 

--- a/test/modules/parser/styles/xviz-style-parser.spec.js
+++ b/test/modules/parser/styles/xviz-style-parser.spec.js
@@ -189,7 +189,7 @@ tape('XVIZStyleParser#Stylesheet#getPropertyDefault', t => {
 
   stylesheet = new Stylesheet([
     {
-      style: {point_color_mode: 'elevation'}
+      style: {point_color_mode: 'ELEVATION'}
     }
   ]);
   t.deepEquals(

--- a/xviz/v2/style.proto
+++ b/xviz/v2/style.proto
@@ -58,6 +58,8 @@ message StyleStreamValue {
   uint32 radius_pixels = 18;
   uint32 font_weight = 19;
   string font_family = 20;
+  PointColorMode point_color_mode = 21;
+  repeated float point_color_domain = 22;
 }
 
 message Color {
@@ -77,4 +79,10 @@ enum TextAlignmentBaseline {
   TOP = 1;
   CENTER = 2;
   BOTTOM = 3;
+}
+
+enum PointColorMode {
+  POINT_COLOR_MODE_INVALID = 0;
+  ELEVATION = 1;
+  DISTANCE_TO_VEHICLE = 2;
 }


### PR DESCRIPTION
Fix error where lowercase constants should have been uppercase.
Support both for backwards compatibility.

Fixes https://github.com/uber/xviz/issues/547