### PR TITLE
Add variable data to XVIZObject

### DIFF
--- a/modules/parser/src/synchronizers/log-slice.js
+++ b/modules/parser/src/synchronizers/log-slice.js
@@ -94,6 +94,13 @@ export default class LogSlice {
           updateObjects(streamName, features);
         }
       }
+
+      for (const streamName in this.variables) {
+        const variables = this.variables[streamName];
+        if (variables.length && variables[0].id) {
+          updateObjects(streamName, variables);
+        }
+      }
     }
 
     frame.objects = XVIZObject.getAllInCurrentFrame(); // Map of XVIZ ids in current slice


### PR DESCRIPTION
This will essentially add variable data (in case it was bound to an object) to `XVIZObject` and will allow reading the data from a `renderObjectLabel` callback.