### PR TITLE
[python] the primitive builder reset state failure

### DIFF
--- a/python/xviz_avs/builder/base_builder.py
+++ b/python/xviz_avs/builder/base_builder.py
@@ -106,8 +106,9 @@ class XVIZBaseBuilder:
 
     def _flush(self):
         raise NotImplementedError("Derived class should implement this method")
+
     def reset(self):
-        self._category = None
+        self._stream_id = None
 
     def _validate_has_prop(self, name):
         if not hasattr(self, name) or not getattr(self, name):

--- a/python/xviz_avs/builder/primitive.py
+++ b/python/xviz_avs/builder/primitive.py
@@ -247,6 +247,7 @@ class XVIZPrimitiveBuilder(XVIZBaseBuilder):
                                      ', '.join(invalid_props), self.stream_id)
 
     def reset(self):
+        super().reset()
         self._type = None
 
         self._image = None

--- a/python/xviz_avs/builder/time_series.py
+++ b/python/xviz_avs/builder/time_series.py
@@ -8,7 +8,7 @@ class XVIZTimeSeriesBuilder(XVIZBaseBuilder):
         # Stores time_series data by timestamp then id
         # They will then be group when constructing final object
         self._data = {}
-        self._reset()
+        self.reset()
 
     def id(self, identifier):
         self._validate_prop_set_once('_id')
@@ -76,7 +76,7 @@ class XVIZTimeSeriesBuilder(XVIZBaseBuilder):
             field_name = "doubles"
         else:
             self._logger.error("The type of input value is not recognized!")
-        
+
         ts_entry = self._data.get(self._timestamp)
         if ts_entry:
             id_entry = ts_entry.get(self._id)
@@ -112,9 +112,10 @@ class XVIZTimeSeriesBuilder(XVIZBaseBuilder):
     def _flush(self):
         self._validate()
         self._add_timestamp_entry()
-        self._reset()
+        self.reset()
 
-    def _reset(self):
+    def reset(self):
+        super().reset()
         self._id = None
         self._value = None
         self._timestamp = None

--- a/python/xviz_avs/builder/ui_primitive.py
+++ b/python/xviz_avs/builder/ui_primitive.py
@@ -28,6 +28,7 @@ class XVIZUIPrimitiveBuilder(XVIZBaseBuilder):
         self._primitives = {}
 
     def reset(self):
+        super().reset()
         self._type = None
         self._columns = None
         self._row = None

--- a/python/xviz_avs/builder/variable.py
+++ b/python/xviz_avs/builder/variable.py
@@ -80,8 +80,9 @@ class XVIZVariableBuilder(XVIZBaseBuilder):
     def _flush(self):
         self._validate()
         self._add_variable_entry()
-        self._reset()
+        self.reset()
 
-    def _reset(self):
+    def reset(self):
+        super().reset()
         self._id = None
         self._values = None


### PR DESCRIPTION
Make sure to reset the primitive `_stream_id` after each usage, and
make sure each class is calling the super class.

It looks like the static `_category` was being improperly reset
instead, that is now changed to `_stream_id` and everything works
correctly with a full state flush each time.