### PR TITLE
Fix python implementation of style_classes

### DIFF
--- a/python/xviz_avs/builder/metadata.py
+++ b/python/xviz_avs/builder/metadata.py
@@ -103,9 +103,9 @@ class XVIZMetadataBuilder:
         if not self._stream_id:
             self._logger.error('A stream must set before adding a style rule.')
             return self
-
-        stream_rule = edict(name=name, style=build_object_style(style))
-        self._temp_stream.style_classes.append(stream_rule)
+        style_class = self._temp_stream.style_classes.add()
+        style_class.name = name
+        style_class.style.MergeFrom(build_object_style(style))
         return self
 
     def log_info(self, data):

--- a/python/xviz_avs/builder/primitive.py
+++ b/python/xviz_avs/builder/primitive.py
@@ -230,7 +230,7 @@ class XVIZPrimitiveBuilder(XVIZBaseBuilder):
             base.style.MergeFrom(build_object_style(self._style))
         if self._classes:
             have_base = True
-            base.classes = self._classes
+            base.classes.extend(self._classes)
 
         if have_base:
             obj.base.MergeFrom(base)

--- a/python/xviz_avs/message.py
+++ b/python/xviz_avs/message.py
@@ -108,6 +108,9 @@ class XVIZMessage:
                 for sdata in dataobj['streams'].values():
                     if 'stream_style' in sdata:
                         _unravel_style_object(sdata['stream_style'])
+                    if 'style_classes' in sdata:
+                        for style_class in sdata['style_classes']:
+                            _unravel_style_object(style_class['style'])
 
             return dataobj
 


### PR DESCRIPTION
Fixes #593

Currently, attempting to use the classes method results in the following exception when you try to build the metadata message:

```
Assigment not allowed for repeated field "classes" in protocol message
```

Protobuf messages do not allow you to assign to repeated fields directly. You must call extend or append to add items instead.

There was also a protobuf-uesage error in the metadata builder.

Additionally, in order for the style_classes to be converted to json properly, I needed to add logic to unravel them in message.py.