### PR TITLE
Add order independent TreeTable Row Child creation

### DIFF
--- a/python/test/test_builder.py
+++ b/python/test/test_builder.py
@@ -211,6 +211,34 @@ class TestUIPrimitiveBuilder(unittest.TestCase):
         }
         assert data['ui_primitives'] == expected
 
+    def test_treetable_row_children_creation_order(self):
+        TEST_COLUMNS = [{'display_text': 'Name', 'type': 'STRING'}]
+        table = self.builder.ui_primitives('/test').treetable(TEST_COLUMNS)
+        # Ensure rows can be created and references remain valid
+        row1 = table.row(1, ['Test Row 1'])
+        row2 = table.row(10, ['Test Row 10'])
+
+        # Children can be added to rows
+        row1.child(2, ['Test Row 2'])
+        row2.child(20, ['Test Row 20'])
+        data = self.builder.get_data().to_object()
+
+        expected = {
+            '/test': {
+                'treetable': {
+                    'columns': TEST_COLUMNS,
+                    'nodes': [
+                        {'id': 1, 'column_values': ['Test Row 1']},
+                        {'parent': 1, 'id': 2, 'column_values': ['Test Row 2']},
+                        {'id': 10, 'column_values': ['Test Row 10']},
+                        {'parent': 10, 'id': 20, 'column_values': ['Test Row 20']}
+                    ]
+                }
+            }
+        }
+        assert data['ui_primitives'] == expected
+
+
     def test_treetable_column_types(self):
         TEST_COLUMNS = [
             {'display_text': 'string', 'type': 'STRING'},

--- a/python/xviz_avs/builder/ui_primitive.py
+++ b/python/xviz_avs/builder/ui_primitive.py
@@ -31,7 +31,7 @@ class XVIZUIPrimitiveBuilder(XVIZBaseBuilder):
         super().reset()
         self._type = None
         self._columns = None
-        self._row = None
+        self._rows = []
 
     def treetable(self, columns):
         if self._type:
@@ -45,15 +45,13 @@ class XVIZUIPrimitiveBuilder(XVIZBaseBuilder):
         return self
 
     def row(self, id_, values):
-        if self._type:
-            self._flush()
-
         self._validate_prop_set_once('_id')
 
-        self._row = XVIZTreeTableRowBuilder(id_, values)
+        row = XVIZTreeTableRowBuilder(id_, values)
+        self._rows.append(row)
         self._type = UIPRIMITIVE_TYPES.TREETABLE
 
-        return self._row
+        return row
 
     def _flush(self):
         self._validate()
@@ -75,7 +73,7 @@ class XVIZUIPrimitiveBuilder(XVIZBaseBuilder):
                 self._validate_has_prop('_columns')
                 self._primitives[self._stream_id].treetable.columns.extend(self._columns)
 
-            if self._row:
-                self._primitives[self._stream_id].treetable.nodes.extend(self._row.get_data())
+            for row in self._rows:
+                self._primitives[self._stream_id].treetable.nodes.extend(row.get_data())
 
         self.reset()


### PR DESCRIPTION
This tracks all row instances created and delays finalizing
the structure rather than doing it upon each row creation.

The recent python fix to properly calling "reset()" exposed a bug in
the behavior of the UIPrimitive builder. It treated creating a row
the same way a Primitive builder would when changing the geometry type.

Instead a "row" is part of the TreeTable so it should just be additive
and not cause a reset.