### PR TITLE
Add order independent TreeTable Row Child creation for js

### DIFF
--- a/modules/builder/src/builders/xviz-ui-primitive-builder.js
+++ b/modules/builder/src/builders/xviz-ui-primitive-builder.js
@@ -69,16 +69,13 @@ export default class XVIZUIPrimitiveBuilder extends XVIZBaseBuilder {
   }
 
   row(id, values) {
-    if (this._type) {
-      this._flush();
-    }
-
     this.validatePropSetOnce('_id');
 
-    this._row = new XVIZTreeTableRowBuilder(id, values);
+    const row = new XVIZTreeTableRowBuilder(id, values);
+    this._rows.push(row);
     this._type = PRIMITIVE_TYPES.treetable;
 
-    return this._row;
+    return row;
   }
 
   _validate() {
@@ -144,8 +141,8 @@ export default class XVIZUIPrimitiveBuilder extends XVIZBaseBuilder {
   _formatPrimitives() {
     switch (this._type) {
       case PRIMITIVE_TYPES.treetable:
-        if (this._row !== null) {
-          return this._row.getData();
+        if (this._rows.length > 0) {
+          return [].concat(...this._rows.map(row => row.getData()));
         }
         break;
 
@@ -159,6 +156,6 @@ export default class XVIZUIPrimitiveBuilder extends XVIZBaseBuilder {
     this._type = null;
 
     this._columns = null;
-    this._row = null;
+    this._rows = [];
   }
 }

--- a/test/modules/builder/builders/xviz-ui-primitive-builder.spec.js
+++ b/test/modules/builder/builders/xviz-ui-primitive-builder.spec.js
@@ -101,3 +101,36 @@ test('XVIZUIPrimitiveBuilder#treetable', t => {
 
   t.end();
 });
+
+test('XVIZUIPrimitiveBuilder#treetable row build order', t => {
+  let builder = new XVIZUIPrimitiveBuilder({validator});
+  builder = new XVIZUIPrimitiveBuilder({validator});
+  const row0 = builder
+    .stream('/test')
+    .treetable(TEST_COLUMNS)
+    .row(0, ['row0']);
+  const row2 = builder.row(2, null);
+
+  row0.child(1, ['row1']);
+  row2.child(3, ['row3']);
+
+  t.deepEquals(
+    builder.getData(),
+    {
+      '/test': {
+        treetable: {
+          columns: TEST_COLUMNS,
+          nodes: [
+            {id: 0, column_values: ['row0']},
+            {id: 1, parent: 0, column_values: ['row1']},
+            {id: 2},
+            {id: 3, parent: 2, column_values: ['row3']}
+          ]
+        }
+      }
+    },
+    'XVIZUIPrimitiveBuilder returns correct data'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
This tracks all row instances created and delays finalizing
the structure rather than doing it upon each row creation.