### PR TITLE
Don't give warnings if attr == 0

### DIFF
--- a/python/test/test_builder.py
+++ b/python/test/test_builder.py
@@ -307,6 +307,22 @@ class TestTimeSeriesBuilder(unittest.TestCase):
         data = self.builder.get_data().to_object()
         assert json.dumps(data['time_series'], sort_keys=True) == json.dumps(expected, sort_keys=True)
 
+    def test_zero_value_attribute_check(self):
+        self.builder.time_series('/test')\
+            .timestamp(20.)\
+            .value(0.)
+
+        self.builder.time_series('/foo')\
+            .timestamp(20.)\
+            .value(2.)
+
+        expected = [{
+            'timestamp': 20.,
+            'streams': ['/test', '/foo'],
+            'values': {'doubles': [0., 2.]}
+        }]
+        data = self.builder.get_data().to_object()
+        assert json.dumps(data['time_series'], sort_keys=True) == json.dumps(expected, sort_keys=True)
 
 class TestFutureInstanceBuilder(unittest.TestCase):
     def setUp(self):

--- a/python/xviz_avs/builder/base_builder.py
+++ b/python/xviz_avs/builder/base_builder.py
@@ -111,7 +111,7 @@ class XVIZBaseBuilder:
         self._stream_id = None
 
     def _validate_has_prop(self, name):
-        if not hasattr(self, name) or not getattr(self, name):
+        if not hasattr(self, name) or (getattr(self, name) == None):
             self._logger.warning("Stream %s: %s is missing", self.stream_id, name)
 
     def _validate_prop_set_once(self, prop, msg=None):


### PR DESCRIPTION
For time_series, if the _value == 0, it will cause an error because "not getattr(self, name)" would be true. Instead, compare to "None"