### PR TITLE
Add workerfarm ID to parseXVIZMessage

### DIFF
--- a/modules/parser/src/parsers/parse-xviz-message.js
+++ b/modules/parser/src/parsers/parse-xviz-message.js
@@ -17,8 +17,8 @@ import {postDeserialize} from './serialize';
 import {getWorkerFarm, initializeWorkerFarm} from './parse-xviz-message-workerfarm';
 
 // Public function for initializing workers
-export function initializeWorkers({worker, maxConcurrency = 4, capacity = null}) {
-  initializeWorkerFarm({worker, maxConcurrency, capacity});
+export function initializeWorkers({id, worker, maxConcurrency = 4, capacity = null}) {
+  initializeWorkerFarm({id, worker, maxConcurrency, capacity});
 }
 
 export function parseXVIZMessage({
@@ -29,16 +29,18 @@ export function parseXVIZMessage({
   debug,
   // worker options
   worker = false,
+  workerId = 'default',
   maxConcurrency = 4,
   capacity = null,
   opts = {}
 }) {
   if (worker) {
-    if (!getWorkerFarm()) {
-      initializeWorkers({worker, maxConcurrency, capacity});
+    const id = workerId;
+    if (!getWorkerFarm(id)) {
+      initializeWorkers({id, worker, maxConcurrency, capacity});
     }
 
-    const workerFarm = getWorkerFarm();
+    const workerFarm = getWorkerFarm(id);
 
     if (debug) {
       workerFarm.debug = debug;

--- a/modules/parser/src/utils/worker-utils.js
+++ b/modules/parser/src/utils/worker-utils.js
@@ -86,8 +86,10 @@ export class WorkerFarm {
     maxConcurrency = 1,
     debug = () => {},
     initialMessage = null,
-    capacity = null
+    capacity = null,
+    id = 'default'
   }) {
+    this.id = id;
     this.workerURL = workerURL;
     this.workers = [];
     this.queue = [];
@@ -141,6 +143,7 @@ export class WorkerFarm {
       const job = queue.shift();
 
       this.debug({
+        id: this.id,
         message: 'processing',
         worker: worker.metadata.name,
         backlog: queue.length,
@@ -153,6 +156,7 @@ export class WorkerFarm {
         .catch(job.onError)
         .then(() => {
           this.debug({
+            id: this.id,
             message: 'waiting',
             worker: worker.metadata.name,
             backlog: queue.length,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,9 +4232,9 @@ camelcase@^6.0.0:
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
 caniuse-lite@^1.0.30001093:
-  version "1.0.30001094"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001094.tgz#0b11d02e1cdc201348dbd8e3e57bd9b6ce82b175"
-  integrity sha512-ufHZNtMaDEuRBpTbqD93tIQnngmJ+oBknjvr0IbFympSdtFpAUFmNv4mVKbb53qltxFx0nK3iy32S9AqkLzUNA==
+  version "1.0.30001211"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz"
+  integrity sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This adds a `workerId` field to the parseXVIZMessage that allows separate worker pools
to be created and used.

This is needed because arbitrarily dropping an XVIZ Message in the general pool can
result in loosing a stream that contains the most recent data.  However, in a situation where
you know what the message contains, then you can apply a different criteria to
the message retention and queue used within the workerFarm.
