### PR TITLE
Allowing treetable row to set parent value for primitive ui builder

### DIFF
--- a/modules/builder/src/builders/xviz-ui-primitive-builder.js
+++ b/modules/builder/src/builders/xviz-ui-primitive-builder.js
@@ -68,10 +68,10 @@ export default class XVIZUIPrimitiveBuilder extends XVIZBaseBuilder {
     return this;
   }
 
-  row(id, values) {
+  row(id, values, parent = null) {
     this.validatePropSetOnce('_id');
 
-    const row = new XVIZTreeTableRowBuilder(id, values);
+    const row = new XVIZTreeTableRowBuilder(id, values, parent);
     this._rows.push(row);
     this._type = PRIMITIVE_TYPES.treetable;
 


### PR DESCRIPTION
Hi,
when I tried to create a treetable I found that I was not able to set a parent id. This fix worked for me. Or is this not necessary and there is another way to achieve this in js?