### PR TITLE
Add single_row method

### DIFF
--- a/python/xviz_avs/builder/ui_primitive.py
+++ b/python/xviz_avs/builder/ui_primitive.py
@@ -44,6 +44,15 @@ class XVIZUIPrimitiveBuilder(XVIZBaseBuilder):
 
         return self
 
+    def single_row(self, id_, values):
+        self._validate_prop_set_once('_id')
+
+        row = XVIZTreeTableRowBuilder(id_, values)
+        self._rows.append(row)
+        self._type = UIPRIMITIVE_TYPES.TREETABLE
+
+        return self
+
     def row(self, id_, values):
         self._validate_prop_set_once('_id')
 


### PR DESCRIPTION
Add this method, because it's a convenient way to create treetables with a lot of rows using Python.
Like this:

``` builder.ui_primitives("name_of_stream") \
            .treetable([
                    {'display_text': 'name', 'type': 0, 'unit': 'this is a name'},
                    {'display_text': 'value', 'type': 0, 'unit': 'This is value'}, ])\
            .single_row(0, [[1, 2], [3, 43]])\
            .single_row(1, [[1, 2], [3, 43]]) ```