### PR TITLE
Decode the requested url - Bisoc

### DIFF
--- a/modules/server/src/server/xviz-server.js
+++ b/modules/server/src/server/xviz-server.js
@@ -23,7 +23,7 @@ function getRequestData(requestUrl) {
   }
 
   return {
-    path: req.pathname,
+    path: decodeURI(req.pathname),
     params
   };
 }
@@ -58,7 +58,7 @@ export class XVIZServer {
   }
 
   async handleSession(socket, request) {
-    this.log(`[> Connection] created: ${request.url}`);
+    this.log(`[> Connection] created: ${decodeURI(request.url)}`);
     const req = getRequestData(request.url);
 
     for (const handler of this.handlers) {


### PR DESCRIPTION
The requested url gets to the Xviz server encoded, because the spacing is not allowed. In order for the url to correctly point the right path, we need to decode the url.