### PR TITLE
Handle rosbags which start at 0.0

### DIFF
--- a/modules/io/src/writers/xviz-binary-writer.js
+++ b/modules/io/src/writers/xviz-binary-writer.js
@@ -115,7 +115,7 @@ export class XVIZBinaryWriter extends XVIZBaseWriter {
     const {startTime, endTime, messages} = this.messageTimings;
     const messageTimings = {};
 
-    if (startTime) {
+    if (Number.isFinite(startTime)) {
       messageTimings.startTime = startTime;
     }
 
@@ -164,7 +164,7 @@ export class XVIZBinaryWriter extends XVIZBaseWriter {
       // Metadata case
       if (log_info) {
         const {start_time, end_time} = log_info || {};
-        if (start_time) {
+        if (Number.isFinite(start_time)) {
           this.messageTimings.startTime = start_time;
         }
 


### PR DESCRIPTION
Handling of rosbags, which start at 0.0 (meaning 1970-01-01 00:00:00.000), was broken due to the check evaluating to `false`.