### PR TITLE
add new style for texture support

### DIFF
--- a/docs/protocol-schema/style-specification.md
+++ b/docs/protocol-schema/style-specification.md
@@ -175,18 +175,22 @@ Supported style properties by primitive types:
 
 ### polygon
 
-| Property                  | Description                                                                                                        | Type            | Default  | Per-stream | Per-object |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------- | -------- | ---------- | ---------- |
-| `extruded`                | Whether to extrude the polygon                                                                                     | Bool            | `false`  | X          |            |
-| `height`                  | The extrusion of the polygon in meters. Only works if `extruded: true`                                             | Number          | `0`      | X          | X          |
-| `filled`                  | Whether to fill the polygon                                                                                        | Bool            | `true`   | X          |            |
-| `stroked`                 | Whether to draw outline around the polygon                                                                         | Bool            | `true`   | X          |            |
-| `fill_color`              | Fill color of the polygon                                                                                          | [Color](#color) | `'#fff'` | X          | X          |
-| `stroke_color`            | Stroke color of the outline                                                                                        | [Color](#color) | `'#000'` | X          | X          |
-| `stroke_width`            | Stroke width of the outline in meters. Only works if `extruded: false`                                             | Number          | `1`      | X          | X          |
-| `stroke_width_min_pixels` | The minimum pixels to draw the outline at. Prevents the lines from being too thin to see at a far-away zoom level. | Number          | (none)   | X          |            |
-| `stroke_width_max_pixels` | The maximum pixels to draw the outline at. Prevents the lines from being too thick at a close-up zoom level.       | Number          | (none)   | X          |            |
-| `opacity`                 | Opacity of the object                                                                                              | Number          | `1`      | X          |            |
+| Property                  | Description                                                                                                        | Type                         | Default  | Per-stream | Per-object |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------- | -------- | ---------- | ---------- |
+| `extruded`                | Whether to extrude the polygon                                                                                     | Bool                         | `false`  | X          |            |
+| `height`                  | The extrusion of the polygon in meters. Only works if `extruded: true`                                             | Number                       | `0`      | X          | X          |
+| `filled`                  | Whether to fill the polygon                                                                                        | Bool                         | `true`   | X          |            |
+| `stroked`                 | Whether to draw outline around the polygon                                                                         | Bool                         | `true`   | X          |            |
+| `fill_color`              | Fill color of the polygon                                                                                          | [Color](#color)              | `'#fff'` | X          | X          |
+| `stroke_color`            | Stroke color of the outline                                                                                        | [Color](#color)              | `'#000'` | X          | X          |
+| `stroke_width`            | Stroke width of the outline in meters. Only works if `extruded: false`                                             | Number                       | `1`      | X          | X          |
+| `stroke_width_min_pixels` | The minimum pixels to draw the outline at. Prevents the lines from being too thin to see at a far-away zoom level. | Number                       | (none)   | X          |            |
+| `stroke_width_max_pixels` | The maximum pixels to draw the outline at. Prevents the lines from being too thick at a close-up zoom level.       | Number                       | (none)   | X          |            |
+| `opacity`                 | Opacity of the object                                                                                              | Number                       | `1`      | X          |            |
+| `texture_id`              | Texture to be applied on the polygon                                                                               | String                       | (none)   | x          |            |
+| `texture_mode`            | To apply texture in either color mode or alpha mode                                                                | [TextureMode](#texture-mode) | 0        | x          |            |
+| `texture_scale`           | Scale of the texture                                                                                               | Number                       | 1        | x          | x          |
+| `texture_rotation`        | Counter-clockwise rotation of the texture in degrees                                                               | Number                       | 0        | x          | x          |
 
 ### polyline
 
@@ -238,6 +242,13 @@ How to color `point` primitives. Can be one of 3 values:
 - `DEFAULT` - use inline colors if provided, or `fill_colors` style otherwise
 - `ELEVATION` - color by elevation from the ground.
 - `DISTANCE_TO_VEHICLE` - color by distance to the vehicle.
+
+### Texture Mode
+
+How to apply texture to polygon. Can be one of 2 values:
+
+- `COLOR` - use all rgba channels from the texture
+- `ALPHA` - only use alpha channel from the texture
 
 ## Remarks
 

--- a/modules/parser/src/styles/xviz-style-property.js
+++ b/modules/parser/src/styles/xviz-style-property.js
@@ -88,6 +88,11 @@ const PROPERTY_FORMATTERS = {
   text_anchor: String,
   text_baseline: String,
 
+  texture_id: String,
+  texture_mode: num,
+  texture_scale: getNumber,
+  texture_rotation: getNumber,
+
   radius: getNumber,
   radius_min_pixels: getNumber,
   radius_max_pixels: getNumber,
@@ -114,6 +119,11 @@ const DEFAULT_STYLES = {
   text_rotation: 0,
   text_anchor: 'MIDDLE',
   text_baseline: 'CENTER',
+
+  texture_id: '',
+  texture_mode: 0,
+  texture_scale: 1,
+  texture_rotation: 0,
 
   radius: 1,
   radius_pixels: 1,

--- a/modules/schema/schema/style/stream_value.schema.json
+++ b/modules/schema/schema/style/stream_value.schema.json
@@ -28,6 +28,18 @@
       "text_baseline": {
         "enum": ["TOP", "CENTER", "BOTTOM"]
       },
+      "texture_id" : {
+        "type": "string"
+      },
+      "texture_mode" : {
+        "enum": ["COLOR", "ALPHA"]
+      },
+      "texture_scale" : {
+        "type": "number"
+      },
+      "texture_rotation" : {
+        "type": "number"
+      },
       "height": {
         "type": "number"
       },
@@ -93,6 +105,10 @@
       {"required": ["text_rotation"]},
       {"required": ["text_anchor"]},
       {"required": ["text_baseline"]},
+      {"required": ["texture_id"]},
+      {"required": ["texture_mode"]},
+      {"required": ["texture_scale"]},
+      {"required": ["texture_rotation"]},
       {"required": ["radius_min_pixels"]},
       {"required": ["radius_max_pixels"]},
       {"required": ["stroke_width_min_pixels"]},

--- a/xviz/v2/style.proto
+++ b/xviz/v2/style.proto
@@ -60,6 +60,10 @@ message StyleStreamValue {
   string font_family = 20;
   PointColorMode point_color_mode = 21;
   repeated float point_color_domain = 22;
+  string texture_id = 23;
+  TextureMode texture_mode = 24;
+  float texture_scale = 25;
+  float texture_rotation = 26;
 }
 
 message Color {
@@ -85,4 +89,9 @@ enum PointColorMode {
   POINT_COLOR_MODE_INVALID = 0;
   ELEVATION = 1;
   DISTANCE_TO_VEHICLE = 2;
+}
+
+enum TextureMode {
+  COLOR = 0;
+  ALPHA = 1;
 }


### PR DESCRIPTION
add the following new styles to support textured polygon

- Per stream
    - texture_id: string
    - texture_mode: enum { color, alpha } 
    - texture_scale: number
    - texture_rotation: number
    
- Per object 
    - texture_scale: number
    - texture_rotation: number
