### PR TITLE
Add new options for run-script debugging purpose

### DIFF
--- a/examples/converters/kitti/src/args.js
+++ b/examples/converters/kitti/src/args.js
@@ -34,6 +34,11 @@ parser.addArgument('--json', {
   help: 'Generate JSON XVIZ output instead of the GLB file format'
 });
 
+parser.addArgument('--pretty-json', {
+  action: 'storeTrue',
+  help: 'Generate pretty formatted JSON'
+});
+
 parser.addArgument('--protobuf', {
   action: 'storeTrue',
   help: 'Generate Protobuf XVIZ output instead of the GLB file file format'
@@ -81,6 +86,7 @@ module.exports = function getArgs() {
     imageMaxHeight: Number(args.image_max_height),
     messageLimit: Number(args.message_limit),
     writeJson: Number(args.json),
+    prettyJson: Number(args.pretty_json),
     writeProtobuf: Number(args.protobuf)
   };
 };

--- a/examples/converters/kitti/src/transform.js
+++ b/examples/converters/kitti/src/transform.js
@@ -31,6 +31,7 @@ module.exports = async function main(args) {
     imageMaxWidth,
     imageMaxHeight,
     writeJson,
+    prettyJson,
     writeProtobuf
   } = args;
 
@@ -53,7 +54,7 @@ module.exports = async function main(args) {
   const sink = new FileSink(outputDir);
   let xvizWriter = null;
   if (writeJson) {
-    xvizWriter = new XVIZJSONWriter(sink);
+    xvizWriter = new XVIZJSONWriter(sink, {prettyJson});
   } else if (writeProtobuf) {
     xvizWriter = new XVIZProtobufWriter(sink);
   } else {

--- a/modules/io/src/writers/xviz-json-writer.js
+++ b/modules/io/src/writers/xviz-json-writer.js
@@ -26,12 +26,12 @@ export class XVIZJSONWriter extends XVIZBaseWriter {
   constructor(sink, options = {}) {
     super(sink);
 
-    const {envelope = true, precision = 10, asArrayBuffer = false} = options;
+    const {envelope = true, precision = 10, asArrayBuffer = false, prettyJson = 0} = options;
     this.messageTimings = {
       messages: new Map()
     };
     this.wroteMessageIndex = null;
-    this.options = {envelope, precision, asArrayBuffer};
+    this.options = {envelope, precision, asArrayBuffer, prettyJson};
   }
 
   // xvizMetadata is the object returned
@@ -44,7 +44,7 @@ export class XVIZJSONWriter extends XVIZBaseWriter {
       xvizMetadata = XVIZEnvelope.Metadata(xvizMetadata);
     }
 
-    const msg = JSON.stringify(xvizMetadata);
+    const msg = JSON.stringify(xvizMetadata, null, this.options.prettyJson ? 2 : 0);
     this.writeToSink('1-frame.json', msg);
   }
 
@@ -66,7 +66,7 @@ export class XVIZJSONWriter extends XVIZBaseWriter {
     };
 
     const jsonXVIZMessage = xvizConvertJson(xvizMessage);
-    const msg = JSON.stringify(jsonXVIZMessage, numberRounder);
+    const msg = JSON.stringify(jsonXVIZMessage, numberRounder, this.options.prettyJson ? 2 : 0);
     this.writeToSink(`${messageName(messageIndex)}.json`, msg);
   }
 
@@ -102,7 +102,7 @@ export class XVIZJSONWriter extends XVIZBaseWriter {
     });
     messageTimings.timing = timing;
 
-    const msg = JSON.stringify(messageTimings);
+    const msg = JSON.stringify(messageTimings, null, this.options.prettyJson ? 2 : 0);
     this.writeToSink('0-frame.json', msg);
     this.wroteMessageIndex = timing.length;
   }

--- a/scripts/run-kitti-example.sh
+++ b/scripts/run-kitti-example.sh
@@ -26,18 +26,38 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 show_help() {
   echo " -h display help information"
   echo " -f force KITTI xviz conversion"
+  echo " -j generate frames in JSON format"
+  echo " -p pretty json output (require -j option)"
+  echo " -m messages limit for debugging purpose"
+  echo " -g generate only, no server start"
+  echo " -d run in debug mode (start-debug)"
 }
 
 # Handle options
 force_xviz_conversion=false
+jsonarg=""
+jsonprettyarg=""
+messagelimitarg=""
+startparam="start"
+generate_only=false
 
-while getopts "hf" opt; do
+while getopts "hfjpm:dg" opt; do
     case "$opt" in
     h|\?)
         show_help
         exit 0
         ;;
     f)  force_xviz_conversion=true
+        ;;
+    j)  jsonarg=" --json "
+        ;;
+    p)  jsonprettyarg=" --pretty-json "
+        ;;
+    m)  messagelimitarg=" --message-limit="${OPTARG}
+        ;;
+    d)  startparam="start-debug"
+        ;;
+    g)  generate_only=true
         ;;
     esac
 done
@@ -62,7 +82,11 @@ OUTPUT_DIR="${SCRIPT_DIR}/../data/generated/kitti/2011_09_26/2011_09_26_drive_00
 if [ "$force_xviz_conversion" = "true" ] || ([ ! -f "${OUTPUT_DIR}/1-frame.json" ] && [ ! -f "${OUTPUT_DIR}/1-frame.glb" ]) ; then
     echo "Generating default KITTI XVIZ data"
     mkdir -p "${OUTPUT_DIR}"
-    (cd "${SCRIPT_DIR}/../examples/converters/kitti" && yarn && yarn start -d ${INPUT_DIR} -o "${OUTPUT_DIR}")
+    (cd "${SCRIPT_DIR}/../examples/converters/kitti" && yarn && yarn ${startparam} -d ${INPUT_DIR} -o "${OUTPUT_DIR}" ${jsonarg} ${jsonprettyarg} ${messagelimitarg})
+fi
+
+if [ "$generate_only" = "true" ] ; then
+    exit 0;
 fi
 
 # Start server & web app


### PR DESCRIPTION
Enable some arguments in run-kitti script, for debugging purposes, such as start-debug, message-limit, json, pretty-json, and generate only